### PR TITLE
[PHX-121] Request that NMI tokenizes the payment method

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -16,6 +16,13 @@ extension MobileReader {
 
 extension CCParameters {
 
+  /// The param value to make NMI add a customer to the customer vault
+  ///
+  /// This should be used with the CCParamCustomerVaultCommand and passed into startTransaction()
+  var ParamValueAddCustomer: String {
+    return "add-customer"
+  }
+
   subscript(key: String) -> String? {
     get {
       guard
@@ -41,6 +48,7 @@ extension CCParameters {
     self[CCParamPaymentMethod] = CCValueCard
     self[CCParamAutoConfirm] = CCValueTrue
     self[CCParamTransactionType] = CCValueSale
+    self[CCParamCustomerVaultCommand] = ParamValueAddCustomer
   }
 
 }


### PR DESCRIPTION
## What is this
NMI has the ability to tokenize a payment method using the card readers. As Fattmerchant, we want to be able to offer that functionality to the users of our SDK

## What did I do?
- Added a ParamValueAddCustomer to ChipDnaUtils since ChipDna didn't have the var that we needed
- Made it so that when a transaction is run, the payment method is tokenized