### PR TITLE
[PHX-124] Store nmi transaction id in transaction meta

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -146,7 +146,8 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
       transactionResult.authCode = result[CCParamAuthCode]
       transactionResult.cardType = result[CCParamCardSchemeId]?.lowercased()
       transactionResult.userReference = result[CCParamUserReference]
-      transactionResult.externalId = result[CCParamCardEaseReference]
+      transactionResult.localId = result[CCParamCardEaseReference]
+      transactionResult.externalId = result[CCParamTransactionId]
 
       if let token = result[CCParamCustomerVaultId] {
         transactionResult.paymentToken = "nmi_\(token)"

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
@@ -50,8 +50,13 @@ struct TransactionResult {
 
   /// The ID of this transaction in the 3rd party responsible for performing it.
   ///
-  /// For example, in the case of NMI, this would be the CardEaseReferenceId
+  /// For example, in the case of NMI, this would be the TransactionID
   var externalId: String?
+
+  /// The ID of this transaction in the local database
+  ///
+  /// For example, in the case of NMI, this would be the CardEaseReferenceId
+  var localId: String?
 
   /// The token that represents this payment method
   internal var paymentToken: String?

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -169,8 +169,12 @@ class TakeMobileReaderPayment {
       dict["nmiUserRef"] = userRef
     }
 
+    if let localId = transactionResult.localId {
+      dict["cardEaseReference"] = localId
+    }
+
     if let externalId = transactionResult.externalId {
-      dict["cardEaseReference"] = externalId
+      dict["nmiTransactionId"] = externalId
     }
 
     return dict.jsonValue()


### PR DESCRIPTION
## What is this?
In order to do linkedRefunds from Omni Gateway, we need to be able to reference a transaction by the id that NMI will recognize

## What did I do?
- Started recording the transaction id that NMI gives us in a `TransactionResult.externalId`
- Moved the storing of the CardEaseReference to `TransactionResult.localId` 
- Added documentation explaining what they both are