### PR TITLE
PHX-384 Tokenizing card does not fail

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/Networking/OmniApi.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Networking/OmniApi.swift
@@ -93,10 +93,6 @@ class OmniApi {
           jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
           let model = try jsonDecoder.decode(T.self, from: data)
           completion(model)
-        } catch DecodingError.typeMismatch(_, let context) {
-          self.log(context)
-        } catch let decodingError as DecodingError {
-          self.log(decodingError)
         } catch {
           var error: OmniException = OmniNetworkingException.couldNotParseResponse(nil)
 


### PR DESCRIPTION
## What is this?
There is an error that isn't being handled. The error is caught, but it's never actually sent back

## What did I do?
Removed two cases that only logged errors. Those errors will now get caught in the general `catch` 