### PR TITLE
PHX-400 Post Transaction Token

### DIFF
--- a/cobertura.xml
+++ b/cobertura.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
-<coverage line-rate="0.0481023830538394" branch-rate="1.0000000000000000" lines-covered="109" lines-valid="2266" branches-covered="0" branches-valid="0" complexity="0.0" timestamp="1587998520" version="Slather 2.4.8">
+<coverage line-rate="0.3027147638527334" branch-rate="1.0000000000000000" lines-covered="814" lines-valid="2689" branches-covered="0" branches-valid="0" complexity="0.0" timestamp="1589921600" version="Slather 2.4.8">
   <sources>
     <source>/Users/tulio/Development/fattmerchant/Fattmerchant-iOS-SDK</source>
   </sources>
@@ -22,7 +22,7 @@
         </class>
       </classes>
     </package>
-    <package name="fattmerchant-ios-sdk.Cardpresent.Data" line-rate="0.3600000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+    <package name="fattmerchant-ios-sdk.Cardpresent.Data" line-rate="0.5000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
       <classes>
         <class name="Amount" filename="fattmerchant-ios-sdk/Cardpresent/Data/Amount.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
@@ -50,53 +50,71 @@
         <class name="TransactionRequest" filename="fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="45" branch="false" hits="0"/>
             <line number="52" branch="false" hits="0"/>
             <line number="53" branch="false" hits="0"/>
             <line number="54" branch="false" hits="0"/>
-            <line number="55" branch="false" hits="0"/>
+            <line number="59" branch="false" hits="0"/>
+            <line number="60" branch="false" hits="0"/>
+            <line number="61" branch="false" hits="0"/>
+            <line number="62" branch="false" hits="0"/>
+            <line number="69" branch="false" hits="0"/>
+            <line number="70" branch="false" hits="0"/>
+            <line number="71" branch="false" hits="0"/>
+            <line number="72" branch="false" hits="0"/>
+            <line number="80" branch="false" hits="0"/>
+            <line number="81" branch="false" hits="0"/>
+            <line number="82" branch="false" hits="0"/>
+            <line number="83" branch="false" hits="0"/>
+            <line number="84" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="Amount" filename="fattmerchant-ios-sdk/Cardpresent/Data/Amount.swift" line-rate="1.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="26" branch="false" hits="10"/>
-            <line number="27" branch="false" hits="10"/>
-            <line number="28" branch="false" hits="10"/>
-            <line number="40" branch="false" hits="27"/>
-            <line number="41" branch="false" hits="27"/>
-            <line number="42" branch="false" hits="27"/>
+            <line number="26" branch="false" hits="21"/>
+            <line number="27" branch="false" hits="21"/>
+            <line number="28" branch="false" hits="21"/>
+            <line number="40" branch="false" hits="28"/>
+            <line number="41" branch="false" hits="28"/>
+            <line number="42" branch="false" hits="28"/>
             <line number="51" branch="false" hits="5"/>
             <line number="52" branch="false" hits="5"/>
             <line number="53" branch="false" hits="5"/>
-            <line number="65" branch="false" hits="10"/>
-            <line number="66" branch="false" hits="10"/>
-            <line number="67" branch="false" hits="10"/>
-            <line number="76" branch="false" hits="28"/>
-            <line number="77" branch="false" hits="28"/>
-            <line number="78" branch="false" hits="28"/>
+            <line number="65" branch="false" hits="17"/>
+            <line number="66" branch="false" hits="17"/>
+            <line number="67" branch="false" hits="17"/>
+            <line number="76" branch="false" hits="38"/>
+            <line number="77" branch="false" hits="38"/>
+            <line number="78" branch="false" hits="38"/>
             <line number="87" branch="false" hits="5"/>
             <line number="88" branch="false" hits="5"/>
             <line number="89" branch="false" hits="5"/>
           </lines>
         </class>
-        <class name="TransactionRequest" filename="fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="TransactionRequest" filename="fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift" line-rate="1.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="45" branch="false" hits="0"/>
-            <line number="52" branch="false" hits="0"/>
-            <line number="53" branch="false" hits="0"/>
-            <line number="54" branch="false" hits="0"/>
-            <line number="55" branch="false" hits="0"/>
+            <line number="52" branch="false" hits="4"/>
+            <line number="53" branch="false" hits="4"/>
+            <line number="54" branch="false" hits="4"/>
+            <line number="59" branch="false" hits="3"/>
+            <line number="60" branch="false" hits="3"/>
+            <line number="61" branch="false" hits="3"/>
+            <line number="62" branch="false" hits="3"/>
+            <line number="69" branch="false" hits="2"/>
+            <line number="70" branch="false" hits="2"/>
+            <line number="71" branch="false" hits="2"/>
+            <line number="72" branch="false" hits="2"/>
+            <line number="80" branch="false" hits="2"/>
+            <line number="81" branch="false" hits="2"/>
+            <line number="82" branch="false" hits="2"/>
+            <line number="83" branch="false" hits="2"/>
+            <line number="84" branch="false" hits="2"/>
           </lines>
         </class>
       </classes>
     </package>
-    <package name="fattmerchant-ios-sdk.Cardpresent.JSON" line-rate="0.1714285714285714" branch-rate="1.0000000000000000" complexity="0.0">
+    <package name="fattmerchant-ios-sdk.Cardpresent.JSON" line-rate="0.2761904761904762" branch-rate="1.0000000000000000" complexity="0.0">
       <classes>
         <class name="JSONValue" filename="fattmerchant-ios-sdk/Cardpresent/JSON/JSONValue.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
@@ -208,35 +226,35 @@
             <line number="200" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="JSONValue" filename="fattmerchant-ios-sdk/Cardpresent/JSON/JSONValue.swift" line-rate="0.3428571428571429" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="JSONValue" filename="fattmerchant-ios-sdk/Cardpresent/JSON/JSONValue.swift" line-rate="0.5523809523809524" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
-            <line number="90" branch="false" hits="0"/>
-            <line number="91" branch="false" hits="0"/>
+            <line number="86" branch="false" hits="10"/>
+            <line number="87" branch="false" hits="10"/>
+            <line number="88" branch="false" hits="10"/>
+            <line number="89" branch="false" hits="10"/>
+            <line number="90" branch="false" hits="4"/>
+            <line number="91" branch="false" hits="10"/>
             <line number="92" branch="false" hits="0"/>
-            <line number="93" branch="false" hits="0"/>
+            <line number="93" branch="false" hits="10"/>
             <line number="94" branch="false" hits="0"/>
-            <line number="95" branch="false" hits="0"/>
+            <line number="95" branch="false" hits="10"/>
             <line number="96" branch="false" hits="0"/>
-            <line number="97" branch="false" hits="0"/>
+            <line number="97" branch="false" hits="10"/>
             <line number="98" branch="false" hits="0"/>
             <line number="99" branch="false" hits="0"/>
             <line number="100" branch="false" hits="0"/>
-            <line number="101" branch="false" hits="0"/>
-            <line number="102" branch="false" hits="0"/>
-            <line number="103" branch="false" hits="0"/>
-            <line number="104" branch="false" hits="0"/>
-            <line number="105" branch="false" hits="0"/>
-            <line number="106" branch="false" hits="0"/>
-            <line number="107" branch="false" hits="0"/>
-            <line number="108" branch="false" hits="0"/>
+            <line number="101" branch="false" hits="10"/>
+            <line number="102" branch="false" hits="6"/>
+            <line number="103" branch="false" hits="6"/>
+            <line number="104" branch="false" hits="10"/>
+            <line number="105" branch="false" hits="10"/>
+            <line number="106" branch="false" hits="10"/>
+            <line number="107" branch="false" hits="10"/>
+            <line number="108" branch="false" hits="10"/>
             <line number="109" branch="false" hits="0"/>
-            <line number="110" branch="false" hits="0"/>
-            <line number="111" branch="false" hits="0"/>
+            <line number="110" branch="false" hits="10"/>
+            <line number="111" branch="false" hits="10"/>
             <line number="113" branch="false" hits="0"/>
             <line number="114" branch="false" hits="0"/>
             <line number="115" branch="false" hits="0"/>
@@ -313,14 +331,14 @@
             <line number="191" branch="false" hits="8"/>
             <line number="192" branch="false" hits="139"/>
             <line number="193" branch="false" hits="139"/>
-            <line number="198" branch="false" hits="0"/>
-            <line number="199" branch="false" hits="0"/>
-            <line number="200" branch="false" hits="0"/>
+            <line number="198" branch="false" hits="4"/>
+            <line number="199" branch="false" hits="4"/>
+            <line number="200" branch="false" hits="4"/>
           </lines>
         </class>
       </classes>
     </package>
-    <package name="fattmerchant-ios-sdk.Cardpresent" line-rate="0.0820895522388060" branch-rate="1.0000000000000000" complexity="0.0">
+    <package name="fattmerchant-ios-sdk.Cardpresent" line-rate="0.4134078212290503" branch-rate="1.0000000000000000" complexity="0.0">
       <classes>
         <class name="MobileReaderDriver" filename="fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
@@ -351,42 +369,29 @@
             <line number="36" branch="false" hits="0"/>
             <line number="37" branch="false" hits="0"/>
             <line number="38" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="70" branch="false" hits="0"/>
-            <line number="83" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
+            <line number="48" branch="false" hits="0"/>
+            <line number="49" branch="false" hits="0"/>
+            <line number="50" branch="false" hits="0"/>
+            <line number="51" branch="false" hits="0"/>
+            <line number="75" branch="false" hits="0"/>
+            <line number="80" branch="false" hits="0"/>
             <line number="84" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="90" branch="false" hits="0"/>
-            <line number="91" branch="false" hits="0"/>
-            <line number="92" branch="false" hits="0"/>
-            <line number="93" branch="false" hits="0"/>
-            <line number="94" branch="false" hits="0"/>
-            <line number="95" branch="false" hits="0"/>
-            <line number="98" branch="false" hits="0"/>
-            <line number="99" branch="false" hits="0"/>
-            <line number="100" branch="false" hits="0"/>
-            <line number="107" branch="false" hits="0"/>
-            <line number="108" branch="false" hits="0"/>
+            <line number="102" branch="false" hits="0"/>
+            <line number="103" branch="false" hits="0"/>
+            <line number="104" branch="false" hits="0"/>
+            <line number="105" branch="false" hits="0"/>
+            <line number="106" branch="false" hits="0"/>
             <line number="109" branch="false" hits="0"/>
             <line number="110" branch="false" hits="0"/>
             <line number="111" branch="false" hits="0"/>
             <line number="112" branch="false" hits="0"/>
             <line number="113" branch="false" hits="0"/>
             <line number="114" branch="false" hits="0"/>
-            <line number="115" branch="false" hits="0"/>
-            <line number="116" branch="false" hits="0"/>
             <line number="117" branch="false" hits="0"/>
             <line number="118" branch="false" hits="0"/>
             <line number="119" branch="false" hits="0"/>
-            <line number="120" branch="false" hits="0"/>
-            <line number="121" branch="false" hits="0"/>
-            <line number="122" branch="false" hits="0"/>
-            <line number="123" branch="false" hits="0"/>
-            <line number="124" branch="false" hits="0"/>
-            <line number="125" branch="false" hits="0"/>
             <line number="126" branch="false" hits="0"/>
             <line number="127" branch="false" hits="0"/>
             <line number="128" branch="false" hits="0"/>
@@ -394,6 +399,12 @@
             <line number="130" branch="false" hits="0"/>
             <line number="131" branch="false" hits="0"/>
             <line number="132" branch="false" hits="0"/>
+            <line number="133" branch="false" hits="0"/>
+            <line number="134" branch="false" hits="0"/>
+            <line number="135" branch="false" hits="0"/>
+            <line number="136" branch="false" hits="0"/>
+            <line number="137" branch="false" hits="0"/>
+            <line number="138" branch="false" hits="0"/>
             <line number="139" branch="false" hits="0"/>
             <line number="140" branch="false" hits="0"/>
             <line number="141" branch="false" hits="0"/>
@@ -410,9 +421,10 @@
             <line number="152" branch="false" hits="0"/>
             <line number="153" branch="false" hits="0"/>
             <line number="154" branch="false" hits="0"/>
-            <line number="162" branch="false" hits="0"/>
-            <line number="163" branch="false" hits="0"/>
-            <line number="164" branch="false" hits="0"/>
+            <line number="155" branch="false" hits="0"/>
+            <line number="156" branch="false" hits="0"/>
+            <line number="157" branch="false" hits="0"/>
+            <line number="158" branch="false" hits="0"/>
             <line number="165" branch="false" hits="0"/>
             <line number="166" branch="false" hits="0"/>
             <line number="167" branch="false" hits="0"/>
@@ -421,9 +433,14 @@
             <line number="170" branch="false" hits="0"/>
             <line number="171" branch="false" hits="0"/>
             <line number="172" branch="false" hits="0"/>
-            <line number="179" branch="false" hits="0"/>
+            <line number="173" branch="false" hits="0"/>
             <line number="180" branch="false" hits="0"/>
             <line number="181" branch="false" hits="0"/>
+            <line number="182" branch="false" hits="0"/>
+            <line number="183" branch="false" hits="0"/>
+            <line number="184" branch="false" hits="0"/>
+            <line number="185" branch="false" hits="0"/>
+            <line number="186" branch="false" hits="0"/>
             <line number="187" branch="false" hits="0"/>
             <line number="188" branch="false" hits="0"/>
             <line number="189" branch="false" hits="0"/>
@@ -433,8 +450,8 @@
             <line number="193" branch="false" hits="0"/>
             <line number="194" branch="false" hits="0"/>
             <line number="195" branch="false" hits="0"/>
-            <line number="196" branch="false" hits="0"/>
-            <line number="197" branch="false" hits="0"/>
+            <line number="203" branch="false" hits="0"/>
+            <line number="204" branch="false" hits="0"/>
             <line number="205" branch="false" hits="0"/>
             <line number="206" branch="false" hits="0"/>
             <line number="207" branch="false" hits="0"/>
@@ -444,15 +461,9 @@
             <line number="211" branch="false" hits="0"/>
             <line number="212" branch="false" hits="0"/>
             <line number="213" branch="false" hits="0"/>
-            <line number="214" branch="false" hits="0"/>
-            <line number="215" branch="false" hits="0"/>
-            <line number="216" branch="false" hits="0"/>
-            <line number="217" branch="false" hits="0"/>
-            <line number="218" branch="false" hits="0"/>
-            <line number="219" branch="false" hits="0"/>
             <line number="220" branch="false" hits="0"/>
-            <line number="226" branch="false" hits="0"/>
-            <line number="227" branch="false" hits="0"/>
+            <line number="221" branch="false" hits="0"/>
+            <line number="222" branch="false" hits="0"/>
             <line number="228" branch="false" hits="0"/>
             <line number="229" branch="false" hits="0"/>
             <line number="230" branch="false" hits="0"/>
@@ -464,6 +475,58 @@
             <line number="236" branch="false" hits="0"/>
             <line number="237" branch="false" hits="0"/>
             <line number="238" branch="false" hits="0"/>
+            <line number="244" branch="false" hits="0"/>
+            <line number="245" branch="false" hits="0"/>
+            <line number="246" branch="false" hits="0"/>
+            <line number="247" branch="false" hits="0"/>
+            <line number="248" branch="false" hits="0"/>
+            <line number="249" branch="false" hits="0"/>
+            <line number="250" branch="false" hits="0"/>
+            <line number="251" branch="false" hits="0"/>
+            <line number="252" branch="false" hits="0"/>
+            <line number="253" branch="false" hits="0"/>
+            <line number="254" branch="false" hits="0"/>
+            <line number="262" branch="false" hits="0"/>
+            <line number="263" branch="false" hits="0"/>
+            <line number="264" branch="false" hits="0"/>
+            <line number="265" branch="false" hits="0"/>
+            <line number="266" branch="false" hits="0"/>
+            <line number="267" branch="false" hits="0"/>
+            <line number="268" branch="false" hits="0"/>
+            <line number="269" branch="false" hits="0"/>
+            <line number="270" branch="false" hits="0"/>
+            <line number="271" branch="false" hits="0"/>
+            <line number="272" branch="false" hits="0"/>
+            <line number="273" branch="false" hits="0"/>
+            <line number="274" branch="false" hits="0"/>
+            <line number="275" branch="false" hits="0"/>
+            <line number="276" branch="false" hits="0"/>
+            <line number="277" branch="false" hits="0"/>
+            <line number="285" branch="false" hits="0"/>
+            <line number="286" branch="false" hits="0"/>
+            <line number="287" branch="false" hits="0"/>
+            <line number="288" branch="false" hits="0"/>
+            <line number="289" branch="false" hits="0"/>
+            <line number="290" branch="false" hits="0"/>
+            <line number="291" branch="false" hits="0"/>
+            <line number="292" branch="false" hits="0"/>
+            <line number="293" branch="false" hits="0"/>
+            <line number="294" branch="false" hits="0"/>
+            <line number="295" branch="false" hits="0"/>
+            <line number="296" branch="false" hits="0"/>
+            <line number="302" branch="false" hits="0"/>
+            <line number="303" branch="false" hits="0"/>
+            <line number="304" branch="false" hits="0"/>
+            <line number="305" branch="false" hits="0"/>
+            <line number="306" branch="false" hits="0"/>
+            <line number="307" branch="false" hits="0"/>
+            <line number="308" branch="false" hits="0"/>
+            <line number="309" branch="false" hits="0"/>
+            <line number="310" branch="false" hits="0"/>
+            <line number="311" branch="false" hits="0"/>
+            <line number="312" branch="false" hits="0"/>
+            <line number="313" branch="false" hits="0"/>
+            <line number="314" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="MobileReaderDriver" filename="fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
@@ -477,284 +540,351 @@
             <line number="21" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="Omni" filename="fattmerchant-ios-sdk/Cardpresent/Omni.swift" line-rate="0.1718750000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="Omni" filename="fattmerchant-ios-sdk/Cardpresent/Omni.swift" line-rate="0.8554913294797688" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="17" branch="false" hits="0"/>
-            <line number="18" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="22" branch="false" hits="0"/>
+            <line number="17" branch="false" hits="1"/>
+            <line number="18" branch="false" hits="1"/>
+            <line number="19" branch="false" hits="1"/>
+            <line number="20" branch="false" hits="1"/>
+            <line number="21" branch="false" hits="1"/>
+            <line number="22" branch="false" hits="1"/>
             <line number="23" branch="false" hits="0"/>
-            <line number="24" branch="false" hits="0"/>
-            <line number="25" branch="false" hits="0"/>
-            <line number="33" branch="false" hits="0"/>
-            <line number="34" branch="false" hits="0"/>
+            <line number="24" branch="false" hits="1"/>
+            <line number="25" branch="false" hits="1"/>
+            <line number="33" branch="false" hits="1"/>
+            <line number="34" branch="false" hits="1"/>
+            <line number="35" branch="false" hits="1"/>
+            <line number="36" branch="false" hits="1"/>
+            <line number="37" branch="false" hits="1"/>
+            <line number="38" branch="false" hits="1"/>
+            <line number="46" branch="false" hits="5"/>
+            <line number="47" branch="false" hits="5"/>
+            <line number="48" branch="false" hits="5"/>
+            <line number="49" branch="false" hits="5"/>
+            <line number="50" branch="false" hits="5"/>
+            <line number="51" branch="false" hits="5"/>
+            <line number="75" branch="false" hits="15"/>
+            <line number="80" branch="false" hits="15"/>
+            <line number="84" branch="false" hits="15"/>
+            <line number="102" branch="false" hits="3"/>
+            <line number="103" branch="false" hits="3"/>
+            <line number="104" branch="false" hits="3"/>
+            <line number="105" branch="false" hits="3"/>
+            <line number="106" branch="false" hits="3"/>
+            <line number="109" branch="false" hits="2"/>
+            <line number="110" branch="false" hits="2"/>
+            <line number="111" branch="false" hits="2"/>
+            <line number="112" branch="false" hits="2"/>
+            <line number="113" branch="false" hits="2"/>
+            <line number="114" branch="false" hits="2"/>
+            <line number="117" branch="false" hits="2"/>
+            <line number="118" branch="false" hits="2"/>
+            <line number="119" branch="false" hits="2"/>
+            <line number="126" branch="false" hits="3"/>
+            <line number="127" branch="false" hits="3"/>
+            <line number="128" branch="false" hits="1"/>
+            <line number="129" branch="false" hits="1"/>
+            <line number="130" branch="false" hits="2"/>
+            <line number="131" branch="false" hits="2"/>
+            <line number="132" branch="false" hits="2"/>
+            <line number="133" branch="false" hits="2"/>
+            <line number="134" branch="false" hits="2"/>
+            <line number="135" branch="false" hits="2"/>
+            <line number="136" branch="false" hits="2"/>
+            <line number="137" branch="false" hits="2"/>
+            <line number="138" branch="false" hits="2"/>
+            <line number="139" branch="false" hits="2"/>
+            <line number="140" branch="false" hits="1"/>
+            <line number="141" branch="false" hits="1"/>
+            <line number="142" branch="false" hits="1"/>
+            <line number="143" branch="false" hits="1"/>
+            <line number="144" branch="false" hits="1"/>
+            <line number="145" branch="false" hits="1"/>
+            <line number="146" branch="false" hits="1"/>
+            <line number="147" branch="false" hits="1"/>
+            <line number="148" branch="false" hits="1"/>
+            <line number="149" branch="false" hits="1"/>
+            <line number="150" branch="false" hits="1"/>
+            <line number="151" branch="false" hits="1"/>
+            <line number="152" branch="false" hits="1"/>
+            <line number="153" branch="false" hits="1"/>
+            <line number="154" branch="false" hits="1"/>
+            <line number="155" branch="false" hits="1"/>
+            <line number="156" branch="false" hits="1"/>
+            <line number="157" branch="false" hits="2"/>
+            <line number="158" branch="false" hits="2"/>
+            <line number="165" branch="false" hits="2"/>
+            <line number="166" branch="false" hits="2"/>
+            <line number="167" branch="false" hits="1"/>
+            <line number="168" branch="false" hits="1"/>
+            <line number="169" branch="false" hits="1"/>
+            <line number="170" branch="false" hits="1"/>
+            <line number="171" branch="false" hits="1"/>
+            <line number="172" branch="false" hits="1"/>
+            <line number="173" branch="false" hits="1"/>
+            <line number="180" branch="false" hits="2"/>
+            <line number="181" branch="false" hits="2"/>
+            <line number="182" branch="false" hits="1"/>
+            <line number="183" branch="false" hits="1"/>
+            <line number="184" branch="false" hits="1"/>
+            <line number="185" branch="false" hits="1"/>
+            <line number="186" branch="false" hits="1"/>
+            <line number="187" branch="false" hits="1"/>
+            <line number="188" branch="false" hits="1"/>
+            <line number="189" branch="false" hits="1"/>
+            <line number="190" branch="false" hits="1"/>
+            <line number="191" branch="false" hits="1"/>
+            <line number="192" branch="false" hits="1"/>
+            <line number="193" branch="false" hits="1"/>
+            <line number="194" branch="false" hits="1"/>
+            <line number="195" branch="false" hits="1"/>
+            <line number="203" branch="false" hits="1"/>
+            <line number="204" branch="false" hits="1"/>
+            <line number="205" branch="false" hits="1"/>
+            <line number="206" branch="false" hits="1"/>
+            <line number="207" branch="false" hits="0"/>
+            <line number="208" branch="false" hits="0"/>
+            <line number="209" branch="false" hits="0"/>
+            <line number="210" branch="false" hits="0"/>
+            <line number="211" branch="false" hits="0"/>
+            <line number="212" branch="false" hits="0"/>
+            <line number="213" branch="false" hits="0"/>
+            <line number="220" branch="false" hits="1"/>
+            <line number="221" branch="false" hits="1"/>
+            <line number="222" branch="false" hits="1"/>
+            <line number="228" branch="false" hits="3"/>
+            <line number="229" branch="false" hits="3"/>
+            <line number="230" branch="false" hits="1"/>
+            <line number="231" branch="false" hits="2"/>
+            <line number="232" branch="false" hits="2"/>
+            <line number="233" branch="false" hits="2"/>
+            <line number="234" branch="false" hits="2"/>
+            <line number="235" branch="false" hits="2"/>
+            <line number="236" branch="false" hits="0"/>
+            <line number="237" branch="false" hits="0"/>
+            <line number="238" branch="false" hits="2"/>
+            <line number="244" branch="false" hits="3"/>
+            <line number="245" branch="false" hits="3"/>
+            <line number="246" branch="false" hits="1"/>
+            <line number="247" branch="false" hits="2"/>
+            <line number="248" branch="false" hits="2"/>
+            <line number="249" branch="false" hits="2"/>
+            <line number="250" branch="false" hits="2"/>
+            <line number="251" branch="false" hits="2"/>
+            <line number="252" branch="false" hits="0"/>
+            <line number="253" branch="false" hits="0"/>
+            <line number="254" branch="false" hits="2"/>
+            <line number="262" branch="false" hits="2"/>
+            <line number="263" branch="false" hits="2"/>
+            <line number="264" branch="false" hits="1"/>
+            <line number="265" branch="false" hits="1"/>
+            <line number="266" branch="false" hits="1"/>
+            <line number="267" branch="false" hits="1"/>
+            <line number="268" branch="false" hits="1"/>
+            <line number="269" branch="false" hits="1"/>
+            <line number="270" branch="false" hits="1"/>
+            <line number="271" branch="false" hits="1"/>
+            <line number="272" branch="false" hits="1"/>
+            <line number="273" branch="false" hits="0"/>
+            <line number="274" branch="false" hits="1"/>
+            <line number="275" branch="false" hits="1"/>
+            <line number="276" branch="false" hits="1"/>
+            <line number="277" branch="false" hits="1"/>
+            <line number="285" branch="false" hits="1"/>
+            <line number="286" branch="false" hits="1"/>
+            <line number="287" branch="false" hits="0"/>
+            <line number="288" branch="false" hits="1"/>
+            <line number="289" branch="false" hits="1"/>
+            <line number="290" branch="false" hits="1"/>
+            <line number="291" branch="false" hits="1"/>
+            <line number="292" branch="false" hits="1"/>
+            <line number="293" branch="false" hits="1"/>
+            <line number="294" branch="false" hits="0"/>
+            <line number="295" branch="false" hits="0"/>
+            <line number="296" branch="false" hits="1"/>
+            <line number="302" branch="false" hits="1"/>
+            <line number="303" branch="false" hits="1"/>
+            <line number="304" branch="false" hits="1"/>
+            <line number="305" branch="false" hits="1"/>
+            <line number="306" branch="false" hits="0"/>
+            <line number="307" branch="false" hits="0"/>
+            <line number="308" branch="false" hits="0"/>
+            <line number="309" branch="false" hits="0"/>
+            <line number="310" branch="false" hits="0"/>
+            <line number="311" branch="false" hits="0"/>
+            <line number="312" branch="false" hits="0"/>
+            <line number="313" branch="false" hits="0"/>
+            <line number="314" branch="false" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+    <package name="fattmerchant-ios-sdk.Cardpresent.Mock" line-rate="0.2666666666666667" branch-rate="1.0000000000000000" complexity="0.0">
+      <classes>
+        <class name="MockDriver" filename="fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="13" branch="false" hits="0"/>
+            <line number="14" branch="false" hits="0"/>
+            <line number="15" branch="false" hits="0"/>
+            <line number="16" branch="false" hits="0"/>
+            <line number="17" branch="false" hits="0"/>
+            <line number="30" branch="false" hits="0"/>
             <line number="35" branch="false" hits="0"/>
             <line number="36" branch="false" hits="0"/>
             <line number="37" branch="false" hits="0"/>
-            <line number="38" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="1"/>
-            <line number="67" branch="false" hits="1"/>
-            <line number="70" branch="false" hits="1"/>
+            <line number="39" branch="false" hits="0"/>
+            <line number="40" branch="false" hits="0"/>
+            <line number="41" branch="false" hits="0"/>
+            <line number="43" branch="false" hits="0"/>
+            <line number="44" branch="false" hits="0"/>
+            <line number="45" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
+            <line number="48" branch="false" hits="0"/>
+            <line number="49" branch="false" hits="0"/>
+            <line number="51" branch="false" hits="0"/>
+            <line number="52" branch="false" hits="0"/>
+            <line number="53" branch="false" hits="0"/>
+            <line number="55" branch="false" hits="0"/>
+            <line number="56" branch="false" hits="0"/>
+            <line number="57" branch="false" hits="0"/>
+            <line number="59" branch="false" hits="0"/>
+            <line number="60" branch="false" hits="0"/>
+            <line number="61" branch="false" hits="0"/>
+            <line number="62" branch="false" hits="0"/>
+            <line number="63" branch="false" hits="0"/>
+            <line number="64" branch="false" hits="0"/>
+            <line number="65" branch="false" hits="0"/>
+            <line number="66" branch="false" hits="0"/>
+            <line number="67" branch="false" hits="0"/>
+            <line number="68" branch="false" hits="0"/>
+            <line number="69" branch="false" hits="0"/>
+            <line number="70" branch="false" hits="0"/>
+            <line number="71" branch="false" hits="0"/>
+            <line number="72" branch="false" hits="0"/>
+            <line number="73" branch="false" hits="0"/>
+            <line number="74" branch="false" hits="0"/>
+            <line number="76" branch="false" hits="0"/>
+            <line number="77" branch="false" hits="0"/>
+            <line number="78" branch="false" hits="0"/>
+            <line number="80" branch="false" hits="0"/>
+            <line number="81" branch="false" hits="0"/>
+            <line number="82" branch="false" hits="0"/>
             <line number="83" branch="false" hits="0"/>
             <line number="84" branch="false" hits="0"/>
             <line number="85" branch="false" hits="0"/>
             <line number="86" branch="false" hits="0"/>
             <line number="87" branch="false" hits="0"/>
+            <line number="88" branch="false" hits="0"/>
+            <line number="89" branch="false" hits="0"/>
             <line number="90" branch="false" hits="0"/>
             <line number="91" branch="false" hits="0"/>
             <line number="92" branch="false" hits="0"/>
             <line number="93" branch="false" hits="0"/>
             <line number="94" branch="false" hits="0"/>
             <line number="95" branch="false" hits="0"/>
+            <line number="97" branch="false" hits="0"/>
             <line number="98" branch="false" hits="0"/>
             <line number="99" branch="false" hits="0"/>
             <line number="100" branch="false" hits="0"/>
+            <line number="101" branch="false" hits="0"/>
+            <line number="102" branch="false" hits="0"/>
+            <line number="103" branch="false" hits="0"/>
+            <line number="104" branch="false" hits="0"/>
+            <line number="105" branch="false" hits="0"/>
+            <line number="106" branch="false" hits="0"/>
             <line number="107" branch="false" hits="0"/>
             <line number="108" branch="false" hits="0"/>
             <line number="109" branch="false" hits="0"/>
             <line number="110" branch="false" hits="0"/>
             <line number="111" branch="false" hits="0"/>
             <line number="112" branch="false" hits="0"/>
-            <line number="113" branch="false" hits="0"/>
-            <line number="114" branch="false" hits="0"/>
-            <line number="115" branch="false" hits="0"/>
-            <line number="116" branch="false" hits="0"/>
-            <line number="117" branch="false" hits="0"/>
-            <line number="118" branch="false" hits="0"/>
-            <line number="119" branch="false" hits="0"/>
-            <line number="120" branch="false" hits="0"/>
-            <line number="121" branch="false" hits="0"/>
-            <line number="122" branch="false" hits="0"/>
-            <line number="123" branch="false" hits="0"/>
-            <line number="124" branch="false" hits="0"/>
-            <line number="125" branch="false" hits="0"/>
-            <line number="126" branch="false" hits="0"/>
-            <line number="127" branch="false" hits="0"/>
-            <line number="128" branch="false" hits="0"/>
-            <line number="129" branch="false" hits="0"/>
-            <line number="130" branch="false" hits="0"/>
-            <line number="131" branch="false" hits="0"/>
-            <line number="132" branch="false" hits="0"/>
-            <line number="139" branch="false" hits="0"/>
-            <line number="140" branch="false" hits="0"/>
-            <line number="141" branch="false" hits="0"/>
-            <line number="142" branch="false" hits="0"/>
-            <line number="143" branch="false" hits="0"/>
-            <line number="144" branch="false" hits="0"/>
-            <line number="145" branch="false" hits="0"/>
-            <line number="146" branch="false" hits="0"/>
-            <line number="147" branch="false" hits="0"/>
-            <line number="148" branch="false" hits="0"/>
-            <line number="149" branch="false" hits="0"/>
-            <line number="150" branch="false" hits="0"/>
-            <line number="151" branch="false" hits="0"/>
-            <line number="152" branch="false" hits="0"/>
-            <line number="153" branch="false" hits="0"/>
-            <line number="154" branch="false" hits="0"/>
-            <line number="162" branch="false" hits="1"/>
-            <line number="163" branch="false" hits="1"/>
-            <line number="164" branch="false" hits="1"/>
-            <line number="165" branch="false" hits="1"/>
-            <line number="166" branch="false" hits="0"/>
-            <line number="167" branch="false" hits="0"/>
-            <line number="168" branch="false" hits="0"/>
-            <line number="169" branch="false" hits="0"/>
-            <line number="170" branch="false" hits="0"/>
-            <line number="171" branch="false" hits="0"/>
-            <line number="172" branch="false" hits="0"/>
-            <line number="179" branch="false" hits="1"/>
-            <line number="180" branch="false" hits="1"/>
-            <line number="181" branch="false" hits="1"/>
-            <line number="187" branch="false" hits="1"/>
-            <line number="188" branch="false" hits="1"/>
-            <line number="189" branch="false" hits="1"/>
-            <line number="190" branch="false" hits="1"/>
-            <line number="191" branch="false" hits="0"/>
-            <line number="192" branch="false" hits="0"/>
-            <line number="193" branch="false" hits="0"/>
-            <line number="194" branch="false" hits="0"/>
-            <line number="195" branch="false" hits="0"/>
-            <line number="196" branch="false" hits="0"/>
-            <line number="197" branch="false" hits="0"/>
-            <line number="205" branch="false" hits="1"/>
-            <line number="206" branch="false" hits="1"/>
-            <line number="207" branch="false" hits="1"/>
-            <line number="208" branch="false" hits="1"/>
-            <line number="209" branch="false" hits="0"/>
-            <line number="210" branch="false" hits="0"/>
-            <line number="211" branch="false" hits="0"/>
-            <line number="212" branch="false" hits="0"/>
-            <line number="213" branch="false" hits="0"/>
-            <line number="214" branch="false" hits="0"/>
-            <line number="215" branch="false" hits="0"/>
-            <line number="216" branch="false" hits="0"/>
-            <line number="217" branch="false" hits="0"/>
-            <line number="218" branch="false" hits="0"/>
-            <line number="219" branch="false" hits="0"/>
-            <line number="220" branch="false" hits="0"/>
-            <line number="226" branch="false" hits="1"/>
-            <line number="227" branch="false" hits="1"/>
-            <line number="228" branch="false" hits="1"/>
-            <line number="229" branch="false" hits="1"/>
-            <line number="230" branch="false" hits="0"/>
-            <line number="231" branch="false" hits="0"/>
-            <line number="232" branch="false" hits="0"/>
-            <line number="233" branch="false" hits="0"/>
-            <line number="234" branch="false" hits="0"/>
-            <line number="235" branch="false" hits="0"/>
-            <line number="236" branch="false" hits="0"/>
-            <line number="237" branch="false" hits="0"/>
-            <line number="238" branch="false" hits="0"/>
           </lines>
         </class>
-      </classes>
-    </package>
-    <package name="fattmerchant-ios-sdk.Cardpresent.Mock" line-rate="0.0078125000000000" branch-rate="1.0000000000000000" complexity="0.0">
-      <classes>
-        <class name="MockDriver" filename="fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="MockDriver" filename="fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift" line-rate="0.5333333333333333" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="13" branch="false" hits="0"/>
-            <line number="15" branch="false" hits="0"/>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="23" branch="false" hits="0"/>
-            <line number="24" branch="false" hits="0"/>
-            <line number="25" branch="false" hits="0"/>
-            <line number="27" branch="false" hits="0"/>
-            <line number="28" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="31" branch="false" hits="0"/>
-            <line number="32" branch="false" hits="0"/>
-            <line number="33" branch="false" hits="0"/>
-            <line number="34" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
-            <line number="36" branch="false" hits="0"/>
-            <line number="37" branch="false" hits="0"/>
-            <line number="38" branch="false" hits="0"/>
-            <line number="39" branch="false" hits="0"/>
-            <line number="40" branch="false" hits="0"/>
-            <line number="41" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="45" branch="false" hits="0"/>
-            <line number="46" branch="false" hits="0"/>
-            <line number="48" branch="false" hits="0"/>
-            <line number="49" branch="false" hits="0"/>
-            <line number="50" branch="false" hits="0"/>
-            <line number="52" branch="false" hits="0"/>
-            <line number="53" branch="false" hits="0"/>
-            <line number="54" branch="false" hits="0"/>
-            <line number="55" branch="false" hits="0"/>
-            <line number="56" branch="false" hits="0"/>
-            <line number="57" branch="false" hits="0"/>
-            <line number="58" branch="false" hits="0"/>
-            <line number="59" branch="false" hits="0"/>
-            <line number="60" branch="false" hits="0"/>
-            <line number="61" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
-            <line number="64" branch="false" hits="0"/>
-            <line number="65" branch="false" hits="0"/>
-            <line number="66" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="70" branch="false" hits="0"/>
-            <line number="71" branch="false" hits="0"/>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="74" branch="false" hits="0"/>
-            <line number="75" branch="false" hits="0"/>
+            <line number="13" branch="false" hits="33"/>
+            <line number="14" branch="false" hits="33"/>
+            <line number="15" branch="false" hits="33"/>
+            <line number="16" branch="false" hits="33"/>
+            <line number="17" branch="false" hits="33"/>
+            <line number="30" branch="false" hits="33"/>
+            <line number="35" branch="false" hits="2"/>
+            <line number="36" branch="false" hits="2"/>
+            <line number="37" branch="false" hits="2"/>
+            <line number="39" branch="false" hits="1"/>
+            <line number="40" branch="false" hits="1"/>
+            <line number="41" branch="false" hits="1"/>
+            <line number="43" branch="false" hits="2"/>
+            <line number="44" branch="false" hits="2"/>
+            <line number="45" branch="false" hits="2"/>
+            <line number="47" branch="false" hits="1"/>
+            <line number="48" branch="false" hits="1"/>
+            <line number="49" branch="false" hits="1"/>
+            <line number="51" branch="false" hits="2"/>
+            <line number="52" branch="false" hits="2"/>
+            <line number="53" branch="false" hits="2"/>
+            <line number="55" branch="false" hits="2"/>
+            <line number="56" branch="false" hits="2"/>
+            <line number="57" branch="false" hits="2"/>
+            <line number="59" branch="false" hits="1"/>
+            <line number="60" branch="false" hits="1"/>
+            <line number="61" branch="false" hits="1"/>
+            <line number="62" branch="false" hits="1"/>
+            <line number="63" branch="false" hits="1"/>
+            <line number="64" branch="false" hits="1"/>
+            <line number="65" branch="false" hits="1"/>
+            <line number="66" branch="false" hits="1"/>
+            <line number="67" branch="false" hits="1"/>
+            <line number="68" branch="false" hits="1"/>
+            <line number="69" branch="false" hits="1"/>
+            <line number="70" branch="false" hits="1"/>
+            <line number="71" branch="false" hits="1"/>
+            <line number="72" branch="false" hits="1"/>
+            <line number="73" branch="false" hits="1"/>
+            <line number="74" branch="false" hits="1"/>
             <line number="76" branch="false" hits="0"/>
             <line number="77" branch="false" hits="0"/>
             <line number="78" branch="false" hits="0"/>
-            <line number="79" branch="false" hits="0"/>
             <line number="80" branch="false" hits="0"/>
             <line number="81" branch="false" hits="0"/>
             <line number="82" branch="false" hits="0"/>
             <line number="83" branch="false" hits="0"/>
             <line number="84" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="MockDriver" filename="fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift" line-rate="0.0156250000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="13" branch="false" hits="1"/>
-            <line number="15" branch="false" hits="0"/>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="23" branch="false" hits="0"/>
-            <line number="24" branch="false" hits="0"/>
-            <line number="25" branch="false" hits="0"/>
-            <line number="27" branch="false" hits="0"/>
-            <line number="28" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="31" branch="false" hits="0"/>
-            <line number="32" branch="false" hits="0"/>
-            <line number="33" branch="false" hits="0"/>
-            <line number="34" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
-            <line number="36" branch="false" hits="0"/>
-            <line number="37" branch="false" hits="0"/>
-            <line number="38" branch="false" hits="0"/>
-            <line number="39" branch="false" hits="0"/>
-            <line number="40" branch="false" hits="0"/>
-            <line number="41" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="45" branch="false" hits="0"/>
-            <line number="46" branch="false" hits="0"/>
-            <line number="48" branch="false" hits="0"/>
-            <line number="49" branch="false" hits="0"/>
-            <line number="50" branch="false" hits="0"/>
-            <line number="52" branch="false" hits="0"/>
-            <line number="53" branch="false" hits="0"/>
-            <line number="54" branch="false" hits="0"/>
-            <line number="55" branch="false" hits="0"/>
-            <line number="56" branch="false" hits="0"/>
-            <line number="57" branch="false" hits="0"/>
-            <line number="58" branch="false" hits="0"/>
-            <line number="59" branch="false" hits="0"/>
-            <line number="60" branch="false" hits="0"/>
-            <line number="61" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
-            <line number="64" branch="false" hits="0"/>
-            <line number="65" branch="false" hits="0"/>
-            <line number="66" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="70" branch="false" hits="0"/>
-            <line number="71" branch="false" hits="0"/>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="74" branch="false" hits="0"/>
-            <line number="75" branch="false" hits="0"/>
-            <line number="76" branch="false" hits="0"/>
-            <line number="77" branch="false" hits="0"/>
-            <line number="78" branch="false" hits="0"/>
-            <line number="79" branch="false" hits="0"/>
-            <line number="80" branch="false" hits="0"/>
-            <line number="81" branch="false" hits="0"/>
-            <line number="82" branch="false" hits="0"/>
-            <line number="83" branch="false" hits="0"/>
-            <line number="84" branch="false" hits="0"/>
+            <line number="85" branch="false" hits="0"/>
+            <line number="86" branch="false" hits="0"/>
+            <line number="87" branch="false" hits="0"/>
+            <line number="88" branch="false" hits="0"/>
+            <line number="89" branch="false" hits="0"/>
+            <line number="90" branch="false" hits="0"/>
+            <line number="91" branch="false" hits="0"/>
+            <line number="92" branch="false" hits="0"/>
+            <line number="93" branch="false" hits="0"/>
+            <line number="94" branch="false" hits="0"/>
+            <line number="95" branch="false" hits="0"/>
+            <line number="97" branch="false" hits="0"/>
+            <line number="98" branch="false" hits="0"/>
+            <line number="99" branch="false" hits="0"/>
+            <line number="100" branch="false" hits="0"/>
+            <line number="101" branch="false" hits="0"/>
+            <line number="102" branch="false" hits="0"/>
+            <line number="103" branch="false" hits="0"/>
+            <line number="104" branch="false" hits="0"/>
+            <line number="105" branch="false" hits="0"/>
+            <line number="106" branch="false" hits="0"/>
+            <line number="107" branch="false" hits="0"/>
+            <line number="108" branch="false" hits="0"/>
+            <line number="109" branch="false" hits="0"/>
+            <line number="110" branch="false" hits="0"/>
+            <line number="111" branch="false" hits="0"/>
+            <line number="112" branch="false" hits="0"/>
           </lines>
         </class>
       </classes>
     </package>
-    <package name="fattmerchant-ios-sdk.Cardpresent.Networking" line-rate="0.0043859649122807" branch-rate="1.0000000000000000" complexity="0.0">
+    <package name="fattmerchant-ios-sdk.Cardpresent.Networking" line-rate="0.2458333333333333" branch-rate="1.0000000000000000" complexity="0.0">
       <classes>
         <class name="Endpoints" filename="fattmerchant-ios-sdk/Cardpresent/Networking/Endpoints.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
@@ -805,29 +935,25 @@
             <line number="30" branch="false" hits="0"/>
             <line number="31" branch="false" hits="0"/>
             <line number="32" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
             <line number="36" branch="false" hits="0"/>
             <line number="37" branch="false" hits="0"/>
             <line number="38" branch="false" hits="0"/>
             <line number="39" branch="false" hits="0"/>
-            <line number="41" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
+            <line number="40" branch="false" hits="0"/>
             <line number="43" branch="false" hits="0"/>
+            <line number="44" branch="false" hits="0"/>
             <line number="45" branch="false" hits="0"/>
-            <line number="48" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
             <line number="49" branch="false" hits="0"/>
             <line number="50" branch="false" hits="0"/>
             <line number="51" branch="false" hits="0"/>
             <line number="52" branch="false" hits="0"/>
             <line number="53" branch="false" hits="0"/>
-            <line number="54" branch="false" hits="0"/>
             <line number="55" branch="false" hits="0"/>
             <line number="56" branch="false" hits="0"/>
             <line number="57" branch="false" hits="0"/>
-            <line number="58" branch="false" hits="0"/>
             <line number="59" branch="false" hits="0"/>
-            <line number="60" branch="false" hits="0"/>
-            <line number="61" branch="false" hits="0"/>
             <line number="62" branch="false" hits="0"/>
             <line number="63" branch="false" hits="0"/>
             <line number="64" branch="false" hits="0"/>
@@ -883,6 +1009,16 @@
             <line number="114" branch="false" hits="0"/>
             <line number="115" branch="false" hits="0"/>
             <line number="116" branch="false" hits="0"/>
+            <line number="117" branch="false" hits="0"/>
+            <line number="118" branch="false" hits="0"/>
+            <line number="119" branch="false" hits="0"/>
+            <line number="120" branch="false" hits="0"/>
+            <line number="121" branch="false" hits="0"/>
+            <line number="122" branch="false" hits="0"/>
+            <line number="123" branch="false" hits="0"/>
+            <line number="124" branch="false" hits="0"/>
+            <line number="125" branch="false" hits="0"/>
+            <line number="126" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="Endpoints" filename="fattmerchant-ios-sdk/Cardpresent/Networking/Endpoints.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
@@ -905,23 +1041,23 @@
             <line number="42" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="Environment" filename="fattmerchant-ios-sdk/Cardpresent/Networking/Environment.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="Environment" filename="fattmerchant-ios-sdk/Cardpresent/Networking/Environment.swift" line-rate="0.9090909090909091" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="18" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
+            <line number="16" branch="false" hits="1"/>
+            <line number="17" branch="false" hits="1"/>
+            <line number="18" branch="false" hits="1"/>
+            <line number="19" branch="false" hits="1"/>
+            <line number="20" branch="false" hits="1"/>
             <line number="21" branch="false" hits="0"/>
-            <line number="22" branch="false" hits="0"/>
-            <line number="23" branch="false" hits="0"/>
-            <line number="25" branch="false" hits="0"/>
-            <line number="26" branch="false" hits="0"/>
-            <line number="27" branch="false" hits="0"/>
+            <line number="22" branch="false" hits="1"/>
+            <line number="23" branch="false" hits="1"/>
+            <line number="25" branch="false" hits="1"/>
+            <line number="26" branch="false" hits="1"/>
+            <line number="27" branch="false" hits="1"/>
           </lines>
         </class>
-        <class name="OmniApi" filename="fattmerchant-ios-sdk/Cardpresent/Networking/OmniApi.swift" line-rate="0.0113636363636364" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="OmniApi" filename="fattmerchant-ios-sdk/Cardpresent/Networking/OmniApi.swift" line-rate="0.5212765957446809" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
             <line number="23" branch="false" hits="0"/>
@@ -934,64 +1070,60 @@
             <line number="30" branch="false" hits="0"/>
             <line number="31" branch="false" hits="0"/>
             <line number="32" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
-            <line number="36" branch="false" hits="0"/>
-            <line number="37" branch="false" hits="0"/>
-            <line number="38" branch="false" hits="0"/>
-            <line number="39" branch="false" hits="0"/>
-            <line number="41" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
+            <line number="36" branch="false" hits="4"/>
+            <line number="37" branch="false" hits="4"/>
+            <line number="38" branch="false" hits="4"/>
+            <line number="39" branch="false" hits="4"/>
+            <line number="40" branch="false" hits="4"/>
             <line number="43" branch="false" hits="0"/>
-            <line number="45" branch="false" hits="1"/>
-            <line number="48" branch="false" hits="0"/>
-            <line number="49" branch="false" hits="0"/>
-            <line number="50" branch="false" hits="0"/>
+            <line number="44" branch="false" hits="0"/>
+            <line number="45" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
+            <line number="49" branch="false" hits="8"/>
+            <line number="50" branch="false" hits="8"/>
             <line number="51" branch="false" hits="0"/>
-            <line number="52" branch="false" hits="0"/>
-            <line number="53" branch="false" hits="0"/>
-            <line number="54" branch="false" hits="0"/>
+            <line number="52" branch="false" hits="8"/>
+            <line number="53" branch="false" hits="8"/>
             <line number="55" branch="false" hits="0"/>
             <line number="56" branch="false" hits="0"/>
             <line number="57" branch="false" hits="0"/>
-            <line number="58" branch="false" hits="0"/>
-            <line number="59" branch="false" hits="0"/>
-            <line number="60" branch="false" hits="0"/>
-            <line number="61" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
+            <line number="59" branch="false" hits="50"/>
+            <line number="62" branch="false" hits="1"/>
+            <line number="63" branch="false" hits="1"/>
             <line number="64" branch="false" hits="0"/>
             <line number="65" branch="false" hits="0"/>
-            <line number="66" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="68" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="70" branch="false" hits="0"/>
-            <line number="71" branch="false" hits="0"/>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="74" branch="false" hits="0"/>
-            <line number="75" branch="false" hits="0"/>
-            <line number="76" branch="false" hits="0"/>
-            <line number="77" branch="false" hits="0"/>
-            <line number="78" branch="false" hits="0"/>
-            <line number="79" branch="false" hits="0"/>
-            <line number="80" branch="false" hits="0"/>
-            <line number="81" branch="false" hits="0"/>
-            <line number="82" branch="false" hits="0"/>
-            <line number="83" branch="false" hits="0"/>
-            <line number="84" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
-            <line number="90" branch="false" hits="0"/>
-            <line number="91" branch="false" hits="0"/>
-            <line number="92" branch="false" hits="0"/>
-            <line number="93" branch="false" hits="0"/>
-            <line number="94" branch="false" hits="0"/>
-            <line number="95" branch="false" hits="0"/>
-            <line number="96" branch="false" hits="0"/>
+            <line number="66" branch="false" hits="1"/>
+            <line number="67" branch="false" hits="1"/>
+            <line number="68" branch="false" hits="1"/>
+            <line number="69" branch="false" hits="1"/>
+            <line number="70" branch="false" hits="1"/>
+            <line number="71" branch="false" hits="1"/>
+            <line number="72" branch="false" hits="1"/>
+            <line number="73" branch="false" hits="1"/>
+            <line number="74" branch="false" hits="1"/>
+            <line number="75" branch="false" hits="1"/>
+            <line number="76" branch="false" hits="1"/>
+            <line number="77" branch="false" hits="1"/>
+            <line number="78" branch="false" hits="1"/>
+            <line number="79" branch="false" hits="1"/>
+            <line number="80" branch="false" hits="1"/>
+            <line number="81" branch="false" hits="1"/>
+            <line number="82" branch="false" hits="1"/>
+            <line number="83" branch="false" hits="1"/>
+            <line number="84" branch="false" hits="1"/>
+            <line number="85" branch="false" hits="1"/>
+            <line number="86" branch="false" hits="1"/>
+            <line number="87" branch="false" hits="1"/>
+            <line number="88" branch="false" hits="1"/>
+            <line number="89" branch="false" hits="1"/>
+            <line number="90" branch="false" hits="1"/>
+            <line number="91" branch="false" hits="1"/>
+            <line number="92" branch="false" hits="1"/>
+            <line number="93" branch="false" hits="1"/>
+            <line number="94" branch="false" hits="1"/>
+            <line number="95" branch="false" hits="1"/>
+            <line number="96" branch="false" hits="1"/>
             <line number="97" branch="false" hits="0"/>
             <line number="98" branch="false" hits="0"/>
             <line number="99" branch="false" hits="0"/>
@@ -1012,11 +1144,21 @@
             <line number="114" branch="false" hits="0"/>
             <line number="115" branch="false" hits="0"/>
             <line number="116" branch="false" hits="0"/>
+            <line number="117" branch="false" hits="0"/>
+            <line number="118" branch="false" hits="0"/>
+            <line number="119" branch="false" hits="0"/>
+            <line number="120" branch="false" hits="0"/>
+            <line number="121" branch="false" hits="1"/>
+            <line number="122" branch="false" hits="1"/>
+            <line number="123" branch="false" hits="1"/>
+            <line number="124" branch="false" hits="1"/>
+            <line number="125" branch="false" hits="1"/>
+            <line number="126" branch="false" hits="1"/>
           </lines>
         </class>
       </classes>
     </package>
-    <package name="fattmerchant-ios-sdk.Cardpresent.Repository" line-rate="0.0064935064935065" branch-rate="1.0000000000000000" complexity="0.0">
+    <package name="fattmerchant-ios-sdk.Cardpresent.Repository" line-rate="0.1496062992125984" branch-rate="1.0000000000000000" complexity="0.0">
       <classes>
         <class name="CustomerRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/CustomerRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
@@ -1061,111 +1203,41 @@
             <line number="29" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="ModelRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/ModelRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="ModelRepository+DefaultImpl" filename="fattmerchant-ios-sdk/Cardpresent/Repository/ModelRepository+DefaultImpl.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="74" branch="false" hits="0"/>
-            <line number="75" branch="false" hits="0"/>
-            <line number="76" branch="false" hits="0"/>
-            <line number="81" branch="false" hits="0"/>
-            <line number="82" branch="false" hits="0"/>
-            <line number="83" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
-            <line number="91" branch="false" hits="0"/>
-            <line number="92" branch="false" hits="0"/>
-            <line number="93" branch="false" hits="0"/>
-            <line number="94" branch="false" hits="0"/>
-            <line number="96" branch="false" hits="0"/>
-            <line number="97" branch="false" hits="0"/>
-            <line number="98" branch="false" hits="0"/>
-            <line number="99" branch="false" hits="0"/>
-            <line number="100" branch="false" hits="0"/>
-            <line number="102" branch="false" hits="0"/>
-            <line number="103" branch="false" hits="0"/>
-            <line number="104" branch="false" hits="0"/>
-            <line number="106" branch="false" hits="0"/>
-            <line number="107" branch="false" hits="0"/>
-            <line number="108" branch="false" hits="0"/>
-            <line number="109" branch="false" hits="0"/>
-            <line number="111" branch="false" hits="0"/>
-            <line number="112" branch="false" hits="0"/>
-            <line number="113" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="PaymentMethodRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/PaymentMethodRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="18" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="30" branch="false" hits="0"/>
-            <line number="31" branch="false" hits="0"/>
-            <line number="38" branch="false" hits="0"/>
-            <line number="39" branch="false" hits="0"/>
-            <line number="40" branch="false" hits="0"/>
-            <line number="41" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="TransactionRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/TransactionRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
+            <line number="12" branch="false" hits="0"/>
+            <line number="13" branch="false" hits="0"/>
+            <line number="14" branch="false" hits="0"/>
             <line number="15" branch="false" hits="0"/>
             <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="CustomerRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/CustomerRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="ModelRepository+EndpointDefaultImpl" filename="fattmerchant-ios-sdk/Cardpresent/Repository/ModelRepository+EndpointDefaultImpl.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
+            <line number="14" branch="false" hits="0"/>
+            <line number="15" branch="false" hits="0"/>
             <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
             <line number="18" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="30" branch="false" hits="0"/>
-            <line number="31" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="InvoiceRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/InvoiceRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="18" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="30" branch="false" hits="0"/>
-            <line number="31" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="MobileReaderDriverRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/MobileReaderDriverRepository.swift" line-rate="0.1000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="14" branch="false" hits="1"/>
             <line number="19" branch="false" hits="0"/>
             <line number="20" branch="false" hits="0"/>
             <line number="21" branch="false" hits="0"/>
             <line number="23" branch="false" hits="0"/>
             <line number="24" branch="false" hits="0"/>
             <line number="25" branch="false" hits="0"/>
+            <line number="26" branch="false" hits="0"/>
             <line number="27" branch="false" hits="0"/>
-            <line number="28" branch="false" hits="0"/>
             <line number="29" branch="false" hits="0"/>
+            <line number="30" branch="false" hits="0"/>
+            <line number="31" branch="false" hits="0"/>
+            <line number="33" branch="false" hits="0"/>
+            <line number="34" branch="false" hits="0"/>
+            <line number="35" branch="false" hits="0"/>
+            <line number="36" branch="false" hits="0"/>
+            <line number="38" branch="false" hits="0"/>
+            <line number="39" branch="false" hits="0"/>
+            <line number="40" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="ModelRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/ModelRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
@@ -1176,33 +1248,6 @@
             <line number="74" branch="false" hits="0"/>
             <line number="75" branch="false" hits="0"/>
             <line number="76" branch="false" hits="0"/>
-            <line number="81" branch="false" hits="0"/>
-            <line number="82" branch="false" hits="0"/>
-            <line number="83" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
-            <line number="91" branch="false" hits="0"/>
-            <line number="92" branch="false" hits="0"/>
-            <line number="93" branch="false" hits="0"/>
-            <line number="94" branch="false" hits="0"/>
-            <line number="96" branch="false" hits="0"/>
-            <line number="97" branch="false" hits="0"/>
-            <line number="98" branch="false" hits="0"/>
-            <line number="99" branch="false" hits="0"/>
-            <line number="100" branch="false" hits="0"/>
-            <line number="102" branch="false" hits="0"/>
-            <line number="103" branch="false" hits="0"/>
-            <line number="104" branch="false" hits="0"/>
-            <line number="106" branch="false" hits="0"/>
-            <line number="107" branch="false" hits="0"/>
-            <line number="108" branch="false" hits="0"/>
-            <line number="109" branch="false" hits="0"/>
-            <line number="111" branch="false" hits="0"/>
-            <line number="112" branch="false" hits="0"/>
-            <line number="113" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="PaymentMethodRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/PaymentMethodRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
@@ -1232,9 +1277,89 @@
             <line number="17" branch="false" hits="0"/>
           </lines>
         </class>
+        <class name="CustomerRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/CustomerRepository.swift" line-rate="0.3333333333333333" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="16" branch="false" hits="0"/>
+            <line number="17" branch="false" hits="0"/>
+            <line number="18" branch="false" hits="0"/>
+            <line number="19" branch="false" hits="0"/>
+            <line number="20" branch="false" hits="0"/>
+            <line number="21" branch="false" hits="0"/>
+            <line number="29" branch="false" hits="18"/>
+            <line number="30" branch="false" hits="18"/>
+            <line number="31" branch="false" hits="18"/>
+          </lines>
+        </class>
+        <class name="InvoiceRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/InvoiceRepository.swift" line-rate="0.3333333333333333" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="16" branch="false" hits="0"/>
+            <line number="17" branch="false" hits="0"/>
+            <line number="18" branch="false" hits="0"/>
+            <line number="19" branch="false" hits="0"/>
+            <line number="20" branch="false" hits="0"/>
+            <line number="21" branch="false" hits="0"/>
+            <line number="29" branch="false" hits="18"/>
+            <line number="30" branch="false" hits="18"/>
+            <line number="31" branch="false" hits="18"/>
+          </lines>
+        </class>
+        <class name="MobileReaderDriverRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/MobileReaderDriverRepository.swift" line-rate="0.7000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="14" branch="false" hits="32"/>
+            <line number="19" branch="false" hits="7"/>
+            <line number="20" branch="false" hits="7"/>
+            <line number="21" branch="false" hits="7"/>
+            <line number="23" branch="false" hits="0"/>
+            <line number="24" branch="false" hits="0"/>
+            <line number="25" branch="false" hits="0"/>
+            <line number="27" branch="false" hits="3"/>
+            <line number="28" branch="false" hits="3"/>
+            <line number="29" branch="false" hits="3"/>
+          </lines>
+        </class>
+        <class name="ModelRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/ModelRepository.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="72" branch="false" hits="0"/>
+            <line number="73" branch="false" hits="0"/>
+            <line number="74" branch="false" hits="0"/>
+            <line number="75" branch="false" hits="0"/>
+            <line number="76" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="PaymentMethodRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/PaymentMethodRepository.swift" line-rate="0.2142857142857143" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="16" branch="false" hits="0"/>
+            <line number="17" branch="false" hits="0"/>
+            <line number="18" branch="false" hits="0"/>
+            <line number="19" branch="false" hits="0"/>
+            <line number="20" branch="false" hits="0"/>
+            <line number="21" branch="false" hits="0"/>
+            <line number="29" branch="false" hits="18"/>
+            <line number="30" branch="false" hits="18"/>
+            <line number="31" branch="false" hits="18"/>
+            <line number="38" branch="false" hits="0"/>
+            <line number="39" branch="false" hits="0"/>
+            <line number="40" branch="false" hits="0"/>
+            <line number="41" branch="false" hits="0"/>
+            <line number="42" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="TransactionRepository" filename="fattmerchant-ios-sdk/Cardpresent/Repository/TransactionRepository.swift" line-rate="1.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="15" branch="false" hits="18"/>
+            <line number="16" branch="false" hits="18"/>
+            <line number="17" branch="false" hits="18"/>
+          </lines>
+        </class>
       </classes>
     </package>
-    <package name="fattmerchant-ios-sdk.Cardpresent.Usecase" line-rate="0.0357142857142857" branch-rate="1.0000000000000000" complexity="0.0">
+    <package name="fattmerchant-ios-sdk.Cardpresent.Usecase" line-rate="0.3766859344894027" branch-rate="1.0000000000000000" complexity="0.0">
       <classes>
         <class name="ConnectMobileReader" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/ConnectMobileReader.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
@@ -1253,6 +1378,42 @@
             <line number="28" branch="false" hits="0"/>
             <line number="29" branch="false" hits="0"/>
             <line number="30" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="DisconnectMobileReader" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/DisconnectMobileReader.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="21" branch="false" hits="0"/>
+            <line number="22" branch="false" hits="0"/>
+            <line number="23" branch="false" hits="0"/>
+            <line number="24" branch="false" hits="0"/>
+            <line number="26" branch="false" hits="0"/>
+            <line number="27" branch="false" hits="0"/>
+            <line number="28" branch="false" hits="0"/>
+            <line number="29" branch="false" hits="0"/>
+            <line number="30" branch="false" hits="0"/>
+            <line number="31" branch="false" hits="0"/>
+            <line number="32" branch="false" hits="0"/>
+            <line number="33" branch="false" hits="0"/>
+            <line number="34" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="GetConnectedMobileReader" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/GetConnectedMobileReader.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="20" branch="false" hits="0"/>
+            <line number="21" branch="false" hits="0"/>
+            <line number="22" branch="false" hits="0"/>
+            <line number="24" branch="false" hits="0"/>
+            <line number="25" branch="false" hits="0"/>
+            <line number="26" branch="false" hits="0"/>
+            <line number="27" branch="false" hits="0"/>
+            <line number="28" branch="false" hits="0"/>
+            <line number="29" branch="false" hits="0"/>
+            <line number="30" branch="false" hits="0"/>
+            <line number="31" branch="false" hits="0"/>
+            <line number="32" branch="false" hits="0"/>
+            <line number="33" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="InitializeDrivers" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/InitializeDrivers.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
@@ -1512,8 +1673,8 @@
             <line number="157" branch="false" hits="0"/>
             <line number="158" branch="false" hits="0"/>
             <line number="159" branch="false" hits="0"/>
-            <line number="163" branch="false" hits="0"/>
-            <line number="164" branch="false" hits="0"/>
+            <line number="160" branch="false" hits="0"/>
+            <line number="161" branch="false" hits="0"/>
             <line number="165" branch="false" hits="0"/>
             <line number="166" branch="false" hits="0"/>
             <line number="167" branch="false" hits="0"/>
@@ -1529,8 +1690,8 @@
             <line number="177" branch="false" hits="0"/>
             <line number="178" branch="false" hits="0"/>
             <line number="179" branch="false" hits="0"/>
-            <line number="185" branch="false" hits="0"/>
-            <line number="186" branch="false" hits="0"/>
+            <line number="180" branch="false" hits="0"/>
+            <line number="181" branch="false" hits="0"/>
             <line number="187" branch="false" hits="0"/>
             <line number="188" branch="false" hits="0"/>
             <line number="189" branch="false" hits="0"/>
@@ -1551,8 +1712,8 @@
             <line number="204" branch="false" hits="0"/>
             <line number="205" branch="false" hits="0"/>
             <line number="206" branch="false" hits="0"/>
+            <line number="207" branch="false" hits="0"/>
             <line number="208" branch="false" hits="0"/>
-            <line number="209" branch="false" hits="0"/>
             <line number="210" branch="false" hits="0"/>
             <line number="211" branch="false" hits="0"/>
             <line number="212" branch="false" hits="0"/>
@@ -1561,8 +1722,8 @@
             <line number="215" branch="false" hits="0"/>
             <line number="216" branch="false" hits="0"/>
             <line number="217" branch="false" hits="0"/>
+            <line number="218" branch="false" hits="0"/>
             <line number="219" branch="false" hits="0"/>
-            <line number="220" branch="false" hits="0"/>
             <line number="221" branch="false" hits="0"/>
             <line number="222" branch="false" hits="0"/>
             <line number="223" branch="false" hits="0"/>
@@ -1596,17 +1757,17 @@
             <line number="251" branch="false" hits="0"/>
             <line number="252" branch="false" hits="0"/>
             <line number="253" branch="false" hits="0"/>
+            <line number="254" branch="false" hits="0"/>
             <line number="255" branch="false" hits="0"/>
-            <line number="256" branch="false" hits="0"/>
             <line number="257" branch="false" hits="0"/>
             <line number="258" branch="false" hits="0"/>
             <line number="259" branch="false" hits="0"/>
             <line number="260" branch="false" hits="0"/>
+            <line number="261" branch="false" hits="0"/>
             <line number="262" branch="false" hits="0"/>
-            <line number="263" branch="false" hits="0"/>
             <line number="264" branch="false" hits="0"/>
+            <line number="265" branch="false" hits="0"/>
             <line number="266" branch="false" hits="0"/>
-            <line number="267" branch="false" hits="0"/>
             <line number="268" branch="false" hits="0"/>
             <line number="269" branch="false" hits="0"/>
             <line number="270" branch="false" hits="0"/>
@@ -1621,8 +1782,8 @@
             <line number="279" branch="false" hits="0"/>
             <line number="280" branch="false" hits="0"/>
             <line number="281" branch="false" hits="0"/>
+            <line number="282" branch="false" hits="0"/>
             <line number="283" branch="false" hits="0"/>
-            <line number="284" branch="false" hits="0"/>
             <line number="285" branch="false" hits="0"/>
             <line number="286" branch="false" hits="0"/>
             <line number="287" branch="false" hits="0"/>
@@ -1637,28 +1798,11 @@
             <line number="296" branch="false" hits="0"/>
             <line number="297" branch="false" hits="0"/>
             <line number="298" branch="false" hits="0"/>
+            <line number="299" branch="false" hits="0"/>
+            <line number="300" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="ConnectMobileReader" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/ConnectMobileReader.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="18" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="22" branch="false" hits="0"/>
-            <line number="23" branch="false" hits="0"/>
-            <line number="24" branch="false" hits="0"/>
-            <line number="25" branch="false" hits="0"/>
-            <line number="26" branch="false" hits="0"/>
-            <line number="27" branch="false" hits="0"/>
-            <line number="28" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="30" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="InitializeDrivers" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/InitializeDrivers.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="TakePayment" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/TakePayment.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
             <line number="16" branch="false" hits="0"/>
@@ -1667,12 +1811,54 @@
             <line number="19" branch="false" hits="0"/>
             <line number="20" branch="false" hits="0"/>
             <line number="21" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="30" branch="false" hits="0"/>
+            <line number="43" branch="false" hits="0"/>
+            <line number="44" branch="false" hits="0"/>
+            <line number="45" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
+            <line number="53" branch="false" hits="0"/>
+            <line number="54" branch="false" hits="0"/>
+            <line number="55" branch="false" hits="0"/>
+            <line number="56" branch="false" hits="0"/>
+            <line number="57" branch="false" hits="0"/>
+            <line number="58" branch="false" hits="0"/>
+            <line number="59" branch="false" hits="0"/>
+            <line number="60" branch="false" hits="0"/>
+            <line number="61" branch="false" hits="0"/>
+            <line number="62" branch="false" hits="0"/>
+            <line number="63" branch="false" hits="0"/>
+            <line number="64" branch="false" hits="0"/>
+            <line number="65" branch="false" hits="0"/>
+            <line number="66" branch="false" hits="0"/>
+            <line number="67" branch="false" hits="0"/>
+            <line number="68" branch="false" hits="0"/>
+            <line number="69" branch="false" hits="0"/>
+            <line number="70" branch="false" hits="0"/>
+            <line number="71" branch="false" hits="0"/>
+            <line number="72" branch="false" hits="0"/>
+            <line number="73" branch="false" hits="0"/>
+            <line number="74" branch="false" hits="0"/>
+            <line number="75" branch="false" hits="0"/>
+            <line number="76" branch="false" hits="0"/>
+            <line number="83" branch="false" hits="0"/>
+            <line number="84" branch="false" hits="0"/>
+            <line number="85" branch="false" hits="0"/>
+            <line number="86" branch="false" hits="0"/>
+            <line number="87" branch="false" hits="0"/>
+            <line number="88" branch="false" hits="0"/>
+            <line number="89" branch="false" hits="0"/>
+            <line number="90" branch="false" hits="0"/>
+            <line number="91" branch="false" hits="0"/>
+            <line number="92" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="TokenizePaymentMethod" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/TokenizePaymentMethod.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
             <line number="31" branch="false" hits="0"/>
             <line number="32" branch="false" hits="0"/>
+            <line number="33" branch="false" hits="0"/>
             <line number="34" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
             <line number="36" branch="false" hits="0"/>
             <line number="37" branch="false" hits="0"/>
             <line number="38" branch="false" hits="0"/>
@@ -1680,8 +1866,144 @@
             <line number="40" branch="false" hits="0"/>
             <line number="41" branch="false" hits="0"/>
             <line number="42" branch="false" hits="0"/>
-            <line number="43" branch="false" hits="0"/>
             <line number="44" branch="false" hits="0"/>
+            <line number="45" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
+            <line number="48" branch="false" hits="0"/>
+            <line number="49" branch="false" hits="0"/>
+            <line number="50" branch="false" hits="0"/>
+            <line number="51" branch="false" hits="0"/>
+            <line number="52" branch="false" hits="0"/>
+            <line number="53" branch="false" hits="0"/>
+            <line number="54" branch="false" hits="0"/>
+            <line number="55" branch="false" hits="0"/>
+            <line number="56" branch="false" hits="0"/>
+            <line number="57" branch="false" hits="0"/>
+            <line number="58" branch="false" hits="0"/>
+            <line number="59" branch="false" hits="0"/>
+            <line number="60" branch="false" hits="0"/>
+            <line number="61" branch="false" hits="0"/>
+            <line number="62" branch="false" hits="0"/>
+            <line number="63" branch="false" hits="0"/>
+            <line number="64" branch="false" hits="0"/>
+            <line number="65" branch="false" hits="0"/>
+            <line number="66" branch="false" hits="0"/>
+            <line number="67" branch="false" hits="0"/>
+            <line number="68" branch="false" hits="0"/>
+            <line number="69" branch="false" hits="0"/>
+            <line number="70" branch="false" hits="0"/>
+            <line number="71" branch="false" hits="0"/>
+            <line number="72" branch="false" hits="0"/>
+            <line number="73" branch="false" hits="0"/>
+            <line number="74" branch="false" hits="0"/>
+            <line number="75" branch="false" hits="0"/>
+            <line number="76" branch="false" hits="0"/>
+            <line number="77" branch="false" hits="0"/>
+            <line number="78" branch="false" hits="0"/>
+            <line number="79" branch="false" hits="0"/>
+            <line number="80" branch="false" hits="0"/>
+            <line number="81" branch="false" hits="0"/>
+            <line number="82" branch="false" hits="0"/>
+            <line number="83" branch="false" hits="0"/>
+            <line number="84" branch="false" hits="0"/>
+            <line number="85" branch="false" hits="0"/>
+            <line number="86" branch="false" hits="0"/>
+            <line number="87" branch="false" hits="0"/>
+            <line number="88" branch="false" hits="0"/>
+            <line number="89" branch="false" hits="0"/>
+            <line number="90" branch="false" hits="0"/>
+            <line number="91" branch="false" hits="0"/>
+            <line number="92" branch="false" hits="0"/>
+            <line number="93" branch="false" hits="0"/>
+            <line number="94" branch="false" hits="0"/>
+            <line number="95" branch="false" hits="0"/>
+            <line number="97" branch="false" hits="0"/>
+            <line number="98" branch="false" hits="0"/>
+            <line number="99" branch="false" hits="0"/>
+            <line number="100" branch="false" hits="0"/>
+            <line number="101" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="ConnectMobileReader" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/ConnectMobileReader.swift" line-rate="0.9285714285714286" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="16" branch="false" hits="1"/>
+            <line number="17" branch="false" hits="1"/>
+            <line number="18" branch="false" hits="1"/>
+            <line number="19" branch="false" hits="1"/>
+            <line number="21" branch="false" hits="1"/>
+            <line number="22" branch="false" hits="1"/>
+            <line number="23" branch="false" hits="1"/>
+            <line number="24" branch="false" hits="1"/>
+            <line number="25" branch="false" hits="1"/>
+            <line number="26" branch="false" hits="0"/>
+            <line number="27" branch="false" hits="1"/>
+            <line number="28" branch="false" hits="1"/>
+            <line number="29" branch="false" hits="1"/>
+            <line number="30" branch="false" hits="1"/>
+          </lines>
+        </class>
+        <class name="DisconnectMobileReader" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/DisconnectMobileReader.swift" line-rate="0.9230769230769231" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="21" branch="false" hits="2"/>
+            <line number="22" branch="false" hits="2"/>
+            <line number="23" branch="false" hits="2"/>
+            <line number="24" branch="false" hits="2"/>
+            <line number="26" branch="false" hits="2"/>
+            <line number="27" branch="false" hits="2"/>
+            <line number="28" branch="false" hits="2"/>
+            <line number="29" branch="false" hits="2"/>
+            <line number="30" branch="false" hits="2"/>
+            <line number="31" branch="false" hits="0"/>
+            <line number="32" branch="false" hits="2"/>
+            <line number="33" branch="false" hits="2"/>
+            <line number="34" branch="false" hits="2"/>
+          </lines>
+        </class>
+        <class name="GetConnectedMobileReader" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/GetConnectedMobileReader.swift" line-rate="0.8461538461538461" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="20" branch="false" hits="2"/>
+            <line number="21" branch="false" hits="2"/>
+            <line number="22" branch="false" hits="2"/>
+            <line number="24" branch="false" hits="2"/>
+            <line number="25" branch="false" hits="2"/>
+            <line number="26" branch="false" hits="2"/>
+            <line number="27" branch="false" hits="0"/>
+            <line number="28" branch="false" hits="0"/>
+            <line number="29" branch="false" hits="2"/>
+            <line number="30" branch="false" hits="2"/>
+            <line number="31" branch="false" hits="2"/>
+            <line number="32" branch="false" hits="2"/>
+            <line number="33" branch="false" hits="2"/>
+          </lines>
+        </class>
+        <class name="InitializeDrivers" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/InitializeDrivers.swift" line-rate="0.6190476190476191" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="16" branch="false" hits="0"/>
+            <line number="17" branch="false" hits="0"/>
+            <line number="18" branch="false" hits="0"/>
+            <line number="19" branch="false" hits="0"/>
+            <line number="20" branch="false" hits="0"/>
+            <line number="21" branch="false" hits="0"/>
+            <line number="29" branch="false" hits="1"/>
+            <line number="30" branch="false" hits="1"/>
+            <line number="31" branch="false" hits="1"/>
+            <line number="32" branch="false" hits="1"/>
+            <line number="34" branch="false" hits="1"/>
+            <line number="35" branch="false" hits="1"/>
+            <line number="36" branch="false" hits="1"/>
+            <line number="37" branch="false" hits="1"/>
+            <line number="38" branch="false" hits="0"/>
+            <line number="39" branch="false" hits="0"/>
+            <line number="40" branch="false" hits="1"/>
+            <line number="41" branch="false" hits="1"/>
+            <line number="42" branch="false" hits="1"/>
+            <line number="43" branch="false" hits="1"/>
+            <line number="44" branch="false" hits="1"/>
           </lines>
         </class>
         <class name="RefundMobileReaderTransaction" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/RefundMobileReaderTransaction.swift" line-rate="0.3068181818181818" branch-rate="1.0000000000000000" complexity="0.0">
@@ -1777,26 +2099,26 @@
             <line number="122" branch="false" hits="10"/>
           </lines>
         </class>
-        <class name="SearchForReaders" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/SearchForReaders.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="SearchForReaders" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/SearchForReaders.swift" line-rate="0.8571428571428571" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="21" branch="false" hits="0"/>
-            <line number="22" branch="false" hits="0"/>
-            <line number="23" branch="false" hits="0"/>
-            <line number="24" branch="false" hits="0"/>
-            <line number="26" branch="false" hits="0"/>
-            <line number="27" branch="false" hits="0"/>
-            <line number="28" branch="false" hits="0"/>
+            <line number="21" branch="false" hits="2"/>
+            <line number="22" branch="false" hits="2"/>
+            <line number="23" branch="false" hits="2"/>
+            <line number="24" branch="false" hits="2"/>
+            <line number="26" branch="false" hits="2"/>
+            <line number="27" branch="false" hits="2"/>
+            <line number="28" branch="false" hits="2"/>
             <line number="29" branch="false" hits="0"/>
             <line number="30" branch="false" hits="0"/>
-            <line number="31" branch="false" hits="0"/>
-            <line number="32" branch="false" hits="0"/>
-            <line number="33" branch="false" hits="0"/>
-            <line number="34" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
+            <line number="31" branch="false" hits="2"/>
+            <line number="32" branch="false" hits="2"/>
+            <line number="33" branch="false" hits="2"/>
+            <line number="34" branch="false" hits="2"/>
+            <line number="35" branch="false" hits="2"/>
           </lines>
         </class>
-        <class name="TakeMobileReaderPayment" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="TakeMobileReaderPayment" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift" line-rate="0.7818930041152263" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
             <line number="22" branch="false" hits="0"/>
@@ -1823,6 +2145,482 @@
             <line number="43" branch="false" hits="0"/>
             <line number="44" branch="false" hits="0"/>
             <line number="45" branch="false" hits="0"/>
+            <line number="66" branch="false" hits="3"/>
+            <line number="67" branch="false" hits="3"/>
+            <line number="68" branch="false" hits="3"/>
+            <line number="69" branch="false" hits="3"/>
+            <line number="70" branch="false" hits="3"/>
+            <line number="71" branch="false" hits="3"/>
+            <line number="72" branch="false" hits="3"/>
+            <line number="73" branch="false" hits="3"/>
+            <line number="74" branch="false" hits="3"/>
+            <line number="76" branch="false" hits="2"/>
+            <line number="77" branch="false" hits="2"/>
+            <line number="78" branch="false" hits="1"/>
+            <line number="79" branch="false" hits="1"/>
+            <line number="80" branch="false" hits="1"/>
+            <line number="81" branch="false" hits="1"/>
+            <line number="82" branch="false" hits="1"/>
+            <line number="83" branch="false" hits="1"/>
+            <line number="84" branch="false" hits="1"/>
+            <line number="85" branch="false" hits="1"/>
+            <line number="86" branch="false" hits="1"/>
+            <line number="87" branch="false" hits="1"/>
+            <line number="88" branch="false" hits="1"/>
+            <line number="89" branch="false" hits="1"/>
+            <line number="90" branch="false" hits="1"/>
+            <line number="91" branch="false" hits="1"/>
+            <line number="92" branch="false" hits="1"/>
+            <line number="93" branch="false" hits="1"/>
+            <line number="94" branch="false" hits="1"/>
+            <line number="95" branch="false" hits="1"/>
+            <line number="96" branch="false" hits="1"/>
+            <line number="97" branch="false" hits="1"/>
+            <line number="98" branch="false" hits="1"/>
+            <line number="99" branch="false" hits="1"/>
+            <line number="100" branch="false" hits="1"/>
+            <line number="101" branch="false" hits="1"/>
+            <line number="102" branch="false" hits="1"/>
+            <line number="103" branch="false" hits="2"/>
+            <line number="105" branch="false" hits="2"/>
+            <line number="106" branch="false" hits="2"/>
+            <line number="107" branch="false" hits="2"/>
+            <line number="108" branch="false" hits="2"/>
+            <line number="109" branch="false" hits="0"/>
+            <line number="110" branch="false" hits="0"/>
+            <line number="111" branch="false" hits="2"/>
+            <line number="112" branch="false" hits="2"/>
+            <line number="113" branch="false" hits="2"/>
+            <line number="114" branch="false" hits="0"/>
+            <line number="115" branch="false" hits="0"/>
+            <line number="116" branch="false" hits="2"/>
+            <line number="117" branch="false" hits="2"/>
+            <line number="118" branch="false" hits="2"/>
+            <line number="119" branch="false" hits="0"/>
+            <line number="120" branch="false" hits="0"/>
+            <line number="121" branch="false" hits="2"/>
+            <line number="122" branch="false" hits="2"/>
+            <line number="123" branch="false" hits="2"/>
+            <line number="124" branch="false" hits="2"/>
+            <line number="125" branch="false" hits="2"/>
+            <line number="126" branch="false" hits="1"/>
+            <line number="127" branch="false" hits="1"/>
+            <line number="128" branch="false" hits="1"/>
+            <line number="129" branch="false" hits="1"/>
+            <line number="130" branch="false" hits="1"/>
+            <line number="131" branch="false" hits="1"/>
+            <line number="132" branch="false" hits="1"/>
+            <line number="133" branch="false" hits="1"/>
+            <line number="134" branch="false" hits="1"/>
+            <line number="135" branch="false" hits="2"/>
+            <line number="136" branch="false" hits="2"/>
+            <line number="137" branch="false" hits="2"/>
+            <line number="138" branch="false" hits="0"/>
+            <line number="139" branch="false" hits="0"/>
+            <line number="140" branch="false" hits="2"/>
+            <line number="141" branch="false" hits="2"/>
+            <line number="142" branch="false" hits="2"/>
+            <line number="143" branch="false" hits="0"/>
+            <line number="144" branch="false" hits="0"/>
+            <line number="145" branch="false" hits="2"/>
+            <line number="146" branch="false" hits="2"/>
+            <line number="147" branch="false" hits="2"/>
+            <line number="148" branch="false" hits="2"/>
+            <line number="149" branch="false" hits="2"/>
+            <line number="150" branch="false" hits="2"/>
+            <line number="151" branch="false" hits="2"/>
+            <line number="152" branch="false" hits="2"/>
+            <line number="153" branch="false" hits="2"/>
+            <line number="154" branch="false" hits="2"/>
+            <line number="155" branch="false" hits="2"/>
+            <line number="156" branch="false" hits="2"/>
+            <line number="157" branch="false" hits="2"/>
+            <line number="158" branch="false" hits="2"/>
+            <line number="159" branch="false" hits="2"/>
+            <line number="160" branch="false" hits="2"/>
+            <line number="161" branch="false" hits="2"/>
+            <line number="165" branch="false" hits="2"/>
+            <line number="166" branch="false" hits="2"/>
+            <line number="167" branch="false" hits="2"/>
+            <line number="168" branch="false" hits="2"/>
+            <line number="169" branch="false" hits="1"/>
+            <line number="170" branch="false" hits="2"/>
+            <line number="171" branch="false" hits="2"/>
+            <line number="172" branch="false" hits="2"/>
+            <line number="173" branch="false" hits="0"/>
+            <line number="174" branch="false" hits="2"/>
+            <line number="175" branch="false" hits="2"/>
+            <line number="176" branch="false" hits="2"/>
+            <line number="177" branch="false" hits="1"/>
+            <line number="178" branch="false" hits="2"/>
+            <line number="179" branch="false" hits="2"/>
+            <line number="180" branch="false" hits="2"/>
+            <line number="181" branch="false" hits="2"/>
+            <line number="187" branch="false" hits="1"/>
+            <line number="188" branch="false" hits="1"/>
+            <line number="189" branch="false" hits="1"/>
+            <line number="190" branch="false" hits="1"/>
+            <line number="191" branch="false" hits="0"/>
+            <line number="192" branch="false" hits="0"/>
+            <line number="193" branch="false" hits="1"/>
+            <line number="194" branch="false" hits="1"/>
+            <line number="195" branch="false" hits="1"/>
+            <line number="196" branch="false" hits="0"/>
+            <line number="197" branch="false" hits="0"/>
+            <line number="198" branch="false" hits="1"/>
+            <line number="199" branch="false" hits="1"/>
+            <line number="200" branch="false" hits="1"/>
+            <line number="201" branch="false" hits="0"/>
+            <line number="202" branch="false" hits="0"/>
+            <line number="203" branch="false" hits="1"/>
+            <line number="204" branch="false" hits="1"/>
+            <line number="205" branch="false" hits="1"/>
+            <line number="206" branch="false" hits="1"/>
+            <line number="207" branch="false" hits="1"/>
+            <line number="208" branch="false" hits="1"/>
+            <line number="210" branch="false" hits="3"/>
+            <line number="211" branch="false" hits="3"/>
+            <line number="212" branch="false" hits="3"/>
+            <line number="213" branch="false" hits="3"/>
+            <line number="214" branch="false" hits="3"/>
+            <line number="215" branch="false" hits="0"/>
+            <line number="216" branch="false" hits="3"/>
+            <line number="217" branch="false" hits="3"/>
+            <line number="218" branch="false" hits="3"/>
+            <line number="219" branch="false" hits="3"/>
+            <line number="221" branch="false" hits="1"/>
+            <line number="222" branch="false" hits="1"/>
+            <line number="223" branch="false" hits="1"/>
+            <line number="224" branch="false" hits="1"/>
+            <line number="225" branch="false" hits="0"/>
+            <line number="226" branch="false" hits="0"/>
+            <line number="227" branch="false" hits="1"/>
+            <line number="228" branch="false" hits="1"/>
+            <line number="229" branch="false" hits="1"/>
+            <line number="230" branch="false" hits="0"/>
+            <line number="231" branch="false" hits="0"/>
+            <line number="232" branch="false" hits="1"/>
+            <line number="233" branch="false" hits="1"/>
+            <line number="234" branch="false" hits="1"/>
+            <line number="235" branch="false" hits="0"/>
+            <line number="236" branch="false" hits="0"/>
+            <line number="237" branch="false" hits="1"/>
+            <line number="238" branch="false" hits="1"/>
+            <line number="239" branch="false" hits="1"/>
+            <line number="240" branch="false" hits="1"/>
+            <line number="241" branch="false" hits="1"/>
+            <line number="242" branch="false" hits="1"/>
+            <line number="243" branch="false" hits="1"/>
+            <line number="244" branch="false" hits="1"/>
+            <line number="245" branch="false" hits="1"/>
+            <line number="246" branch="false" hits="1"/>
+            <line number="247" branch="false" hits="1"/>
+            <line number="248" branch="false" hits="1"/>
+            <line number="249" branch="false" hits="1"/>
+            <line number="250" branch="false" hits="0"/>
+            <line number="251" branch="false" hits="1"/>
+            <line number="252" branch="false" hits="1"/>
+            <line number="253" branch="false" hits="1"/>
+            <line number="254" branch="false" hits="1"/>
+            <line number="255" branch="false" hits="1"/>
+            <line number="257" branch="false" hits="1"/>
+            <line number="258" branch="false" hits="1"/>
+            <line number="259" branch="false" hits="1"/>
+            <line number="260" branch="false" hits="1"/>
+            <line number="261" branch="false" hits="1"/>
+            <line number="262" branch="false" hits="1"/>
+            <line number="264" branch="false" hits="1"/>
+            <line number="265" branch="false" hits="1"/>
+            <line number="266" branch="false" hits="1"/>
+            <line number="268" branch="false" hits="1"/>
+            <line number="269" branch="false" hits="1"/>
+            <line number="270" branch="false" hits="1"/>
+            <line number="271" branch="false" hits="1"/>
+            <line number="272" branch="false" hits="1"/>
+            <line number="273" branch="false" hits="1"/>
+            <line number="274" branch="false" hits="1"/>
+            <line number="275" branch="false" hits="1"/>
+            <line number="276" branch="false" hits="1"/>
+            <line number="277" branch="false" hits="0"/>
+            <line number="278" branch="false" hits="0"/>
+            <line number="279" branch="false" hits="1"/>
+            <line number="280" branch="false" hits="1"/>
+            <line number="281" branch="false" hits="1"/>
+            <line number="282" branch="false" hits="1"/>
+            <line number="283" branch="false" hits="1"/>
+            <line number="285" branch="false" hits="2"/>
+            <line number="286" branch="false" hits="2"/>
+            <line number="287" branch="false" hits="2"/>
+            <line number="288" branch="false" hits="0"/>
+            <line number="289" branch="false" hits="0"/>
+            <line number="290" branch="false" hits="2"/>
+            <line number="291" branch="false" hits="2"/>
+            <line number="292" branch="false" hits="2"/>
+            <line number="293" branch="false" hits="2"/>
+            <line number="294" branch="false" hits="1"/>
+            <line number="295" branch="false" hits="2"/>
+            <line number="296" branch="false" hits="1"/>
+            <line number="297" branch="false" hits="2"/>
+            <line number="298" branch="false" hits="2"/>
+            <line number="299" branch="false" hits="2"/>
+            <line number="300" branch="false" hits="2"/>
+          </lines>
+        </class>
+        <class name="TakePayment" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/TakePayment.swift" line-rate="1.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="16" branch="false" hits="2"/>
+            <line number="17" branch="false" hits="2"/>
+            <line number="18" branch="false" hits="2"/>
+            <line number="19" branch="false" hits="2"/>
+            <line number="20" branch="false" hits="2"/>
+            <line number="21" branch="false" hits="2"/>
+            <line number="43" branch="false" hits="6"/>
+            <line number="44" branch="false" hits="6"/>
+            <line number="45" branch="false" hits="6"/>
+            <line number="46" branch="false" hits="6"/>
+            <line number="47" branch="false" hits="6"/>
+            <line number="53" branch="false" hits="5"/>
+            <line number="54" branch="false" hits="5"/>
+            <line number="55" branch="false" hits="5"/>
+            <line number="56" branch="false" hits="1"/>
+            <line number="57" branch="false" hits="1"/>
+            <line number="58" branch="false" hits="4"/>
+            <line number="59" branch="false" hits="4"/>
+            <line number="60" branch="false" hits="4"/>
+            <line number="61" branch="false" hits="4"/>
+            <line number="62" branch="false" hits="4"/>
+            <line number="63" branch="false" hits="3"/>
+            <line number="64" branch="false" hits="3"/>
+            <line number="65" branch="false" hits="1"/>
+            <line number="66" branch="false" hits="1"/>
+            <line number="67" branch="false" hits="2"/>
+            <line number="68" branch="false" hits="2"/>
+            <line number="69" branch="false" hits="2"/>
+            <line number="70" branch="false" hits="2"/>
+            <line number="71" branch="false" hits="2"/>
+            <line number="72" branch="false" hits="2"/>
+            <line number="73" branch="false" hits="2"/>
+            <line number="74" branch="false" hits="2"/>
+            <line number="75" branch="false" hits="2"/>
+            <line number="76" branch="false" hits="4"/>
+            <line number="83" branch="false" hits="3"/>
+            <line number="84" branch="false" hits="3"/>
+            <line number="85" branch="false" hits="3"/>
+            <line number="86" branch="false" hits="3"/>
+            <line number="87" branch="false" hits="3"/>
+            <line number="88" branch="false" hits="3"/>
+            <line number="89" branch="false" hits="3"/>
+            <line number="90" branch="false" hits="3"/>
+            <line number="91" branch="false" hits="3"/>
+            <line number="92" branch="false" hits="3"/>
+          </lines>
+        </class>
+        <class name="TokenizePaymentMethod" filename="fattmerchant-ios-sdk/Cardpresent/Usecase/TokenizePaymentMethod.swift" line-rate="1.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="31" branch="false" hits="7"/>
+            <line number="32" branch="false" hits="7"/>
+            <line number="33" branch="false" hits="7"/>
+            <line number="34" branch="false" hits="7"/>
+            <line number="36" branch="false" hits="7"/>
+            <line number="37" branch="false" hits="7"/>
+            <line number="38" branch="false" hits="1"/>
+            <line number="39" branch="false" hits="1"/>
+            <line number="40" branch="false" hits="6"/>
+            <line number="41" branch="false" hits="6"/>
+            <line number="42" branch="false" hits="6"/>
+            <line number="44" branch="false" hits="6"/>
+            <line number="45" branch="false" hits="6"/>
+            <line number="46" branch="false" hits="1"/>
+            <line number="47" branch="false" hits="1"/>
+            <line number="48" branch="false" hits="5"/>
+            <line number="49" branch="false" hits="5"/>
+            <line number="50" branch="false" hits="5"/>
+            <line number="51" branch="false" hits="5"/>
+            <line number="52" branch="false" hits="5"/>
+            <line number="53" branch="false" hits="1"/>
+            <line number="54" branch="false" hits="1"/>
+            <line number="55" branch="false" hits="5"/>
+            <line number="56" branch="false" hits="5"/>
+            <line number="57" branch="false" hits="5"/>
+            <line number="58" branch="false" hits="5"/>
+            <line number="59" branch="false" hits="5"/>
+            <line number="60" branch="false" hits="5"/>
+            <line number="61" branch="false" hits="5"/>
+            <line number="62" branch="false" hits="5"/>
+            <line number="63" branch="false" hits="5"/>
+            <line number="64" branch="false" hits="5"/>
+            <line number="65" branch="false" hits="5"/>
+            <line number="66" branch="false" hits="5"/>
+            <line number="67" branch="false" hits="5"/>
+            <line number="68" branch="false" hits="5"/>
+            <line number="69" branch="false" hits="5"/>
+            <line number="70" branch="false" hits="5"/>
+            <line number="71" branch="false" hits="5"/>
+            <line number="72" branch="false" hits="5"/>
+            <line number="73" branch="false" hits="5"/>
+            <line number="74" branch="false" hits="5"/>
+            <line number="75" branch="false" hits="5"/>
+            <line number="76" branch="false" hits="5"/>
+            <line number="77" branch="false" hits="5"/>
+            <line number="78" branch="false" hits="5"/>
+            <line number="79" branch="false" hits="5"/>
+            <line number="80" branch="false" hits="5"/>
+            <line number="81" branch="false" hits="5"/>
+            <line number="82" branch="false" hits="5"/>
+            <line number="83" branch="false" hits="5"/>
+            <line number="84" branch="false" hits="5"/>
+            <line number="85" branch="false" hits="5"/>
+            <line number="86" branch="false" hits="5"/>
+            <line number="87" branch="false" hits="5"/>
+            <line number="88" branch="false" hits="5"/>
+            <line number="89" branch="false" hits="5"/>
+            <line number="90" branch="false" hits="5"/>
+            <line number="91" branch="false" hits="5"/>
+            <line number="92" branch="false" hits="5"/>
+            <line number="93" branch="false" hits="5"/>
+            <line number="94" branch="false" hits="5"/>
+            <line number="95" branch="false" hits="5"/>
+            <line number="97" branch="false" hits="6"/>
+            <line number="98" branch="false" hits="6"/>
+            <line number="99" branch="false" hits="6"/>
+            <line number="100" branch="false" hits="6"/>
+            <line number="101" branch="false" hits="6"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+    <package name="fattmerchant-ios-sdk" line-rate="0.1141732283464567" branch-rate="1.0000000000000000" complexity="0.0">
+      <classes>
+        <class name="FattmerchantApi" filename="fattmerchant-ios-sdk/FattmerchantApi.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="62" branch="false" hits="0"/>
+            <line number="63" branch="false" hits="0"/>
+            <line number="64" branch="false" hits="0"/>
+            <line number="67" branch="false" hits="0"/>
+            <line number="68" branch="false" hits="0"/>
+            <line number="69" branch="false" hits="0"/>
+            <line number="78" branch="false" hits="0"/>
+            <line number="79" branch="false" hits="0"/>
+            <line number="80" branch="false" hits="0"/>
+            <line number="85" branch="false" hits="0"/>
+            <line number="86" branch="false" hits="0"/>
+            <line number="87" branch="false" hits="0"/>
+            <line number="88" branch="false" hits="0"/>
+            <line number="89" branch="false" hits="0"/>
+            <line number="90" branch="false" hits="0"/>
+            <line number="91" branch="false" hits="0"/>
+            <line number="92" branch="false" hits="0"/>
+            <line number="93" branch="false" hits="0"/>
+            <line number="94" branch="false" hits="0"/>
+            <line number="103" branch="false" hits="0"/>
+            <line number="104" branch="false" hits="0"/>
+            <line number="105" branch="false" hits="0"/>
+            <line number="110" branch="false" hits="0"/>
+            <line number="111" branch="false" hits="0"/>
+            <line number="112" branch="false" hits="0"/>
+            <line number="113" branch="false" hits="0"/>
+            <line number="114" branch="false" hits="0"/>
+            <line number="115" branch="false" hits="0"/>
+            <line number="116" branch="false" hits="0"/>
+            <line number="117" branch="false" hits="0"/>
+            <line number="118" branch="false" hits="0"/>
+            <line number="119" branch="false" hits="0"/>
+            <line number="121" branch="false" hits="0"/>
+            <line number="122" branch="false" hits="0"/>
+            <line number="123" branch="false" hits="0"/>
+            <line number="124" branch="false" hits="0"/>
+            <line number="125" branch="false" hits="0"/>
+            <line number="126" branch="false" hits="0"/>
+            <line number="127" branch="false" hits="0"/>
+            <line number="128" branch="false" hits="0"/>
+            <line number="129" branch="false" hits="0"/>
+            <line number="130" branch="false" hits="0"/>
+            <line number="131" branch="false" hits="0"/>
+            <line number="132" branch="false" hits="0"/>
+            <line number="133" branch="false" hits="0"/>
+            <line number="134" branch="false" hits="0"/>
+            <line number="135" branch="false" hits="0"/>
+            <line number="136" branch="false" hits="0"/>
+            <line number="137" branch="false" hits="0"/>
+            <line number="138" branch="false" hits="0"/>
+            <line number="139" branch="false" hits="0"/>
+            <line number="140" branch="false" hits="0"/>
+            <line number="141" branch="false" hits="0"/>
+            <line number="142" branch="false" hits="0"/>
+            <line number="143" branch="false" hits="0"/>
+            <line number="144" branch="false" hits="0"/>
+            <line number="145" branch="false" hits="0"/>
+            <line number="146" branch="false" hits="0"/>
+            <line number="147" branch="false" hits="0"/>
+            <line number="148" branch="false" hits="0"/>
+            <line number="149" branch="false" hits="0"/>
+            <line number="150" branch="false" hits="0"/>
+            <line number="151" branch="false" hits="0"/>
+            <line number="152" branch="false" hits="0"/>
+            <line number="153" branch="false" hits="0"/>
+            <line number="154" branch="false" hits="0"/>
+            <line number="155" branch="false" hits="0"/>
+            <line number="156" branch="false" hits="0"/>
+            <line number="157" branch="false" hits="0"/>
+            <line number="158" branch="false" hits="0"/>
+            <line number="159" branch="false" hits="0"/>
+            <line number="160" branch="false" hits="0"/>
+            <line number="161" branch="false" hits="0"/>
+            <line number="162" branch="false" hits="0"/>
+            <line number="163" branch="false" hits="0"/>
+            <line number="164" branch="false" hits="0"/>
+            <line number="165" branch="false" hits="0"/>
+            <line number="166" branch="false" hits="0"/>
+            <line number="167" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="FattmerchantConfiguration" filename="fattmerchant-ios-sdk/FattmerchantConfiguration.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="32" branch="false" hits="0"/>
+            <line number="34" branch="false" hits="0"/>
+            <line number="35" branch="false" hits="0"/>
+            <line number="36" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="Networking" filename="fattmerchant-ios-sdk/Networking.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="28" branch="false" hits="0"/>
+            <line number="29" branch="false" hits="0"/>
+            <line number="30" branch="false" hits="0"/>
+            <line number="32" branch="false" hits="0"/>
+            <line number="33" branch="false" hits="0"/>
+            <line number="34" branch="false" hits="0"/>
+            <line number="35" branch="false" hits="0"/>
+            <line number="36" branch="false" hits="0"/>
+            <line number="37" branch="false" hits="0"/>
+            <line number="38" branch="false" hits="0"/>
+            <line number="39" branch="false" hits="0"/>
+            <line number="40" branch="false" hits="0"/>
+            <line number="42" branch="false" hits="0"/>
+            <line number="43" branch="false" hits="0"/>
+            <line number="44" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
+            <line number="48" branch="false" hits="0"/>
+            <line number="50" branch="false" hits="0"/>
+            <line number="51" branch="false" hits="0"/>
+            <line number="52" branch="false" hits="0"/>
+            <line number="53" branch="false" hits="0"/>
+            <line number="55" branch="false" hits="0"/>
+            <line number="56" branch="false" hits="0"/>
+            <line number="57" branch="false" hits="0"/>
+            <line number="58" branch="false" hits="0"/>
+            <line number="60" branch="false" hits="0"/>
+            <line number="61" branch="false" hits="0"/>
+            <line number="62" branch="false" hits="0"/>
+            <line number="63" branch="false" hits="0"/>
+            <line number="64" branch="false" hits="0"/>
+            <line number="65" branch="false" hits="0"/>
             <line number="66" branch="false" hits="0"/>
             <line number="67" branch="false" hits="0"/>
             <line number="68" branch="false" hits="0"/>
@@ -1832,6 +2630,174 @@
             <line number="72" branch="false" hits="0"/>
             <line number="73" branch="false" hits="0"/>
             <line number="74" branch="false" hits="0"/>
+            <line number="75" branch="false" hits="0"/>
+            <line number="76" branch="false" hits="0"/>
+            <line number="77" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="FattmerchantApi" filename="fattmerchant-ios-sdk/FattmerchantApi.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="62" branch="false" hits="0"/>
+            <line number="63" branch="false" hits="0"/>
+            <line number="64" branch="false" hits="0"/>
+            <line number="67" branch="false" hits="0"/>
+            <line number="68" branch="false" hits="0"/>
+            <line number="69" branch="false" hits="0"/>
+            <line number="78" branch="false" hits="0"/>
+            <line number="79" branch="false" hits="0"/>
+            <line number="80" branch="false" hits="0"/>
+            <line number="85" branch="false" hits="0"/>
+            <line number="86" branch="false" hits="0"/>
+            <line number="87" branch="false" hits="0"/>
+            <line number="88" branch="false" hits="0"/>
+            <line number="89" branch="false" hits="0"/>
+            <line number="90" branch="false" hits="0"/>
+            <line number="91" branch="false" hits="0"/>
+            <line number="92" branch="false" hits="0"/>
+            <line number="93" branch="false" hits="0"/>
+            <line number="94" branch="false" hits="0"/>
+            <line number="103" branch="false" hits="0"/>
+            <line number="104" branch="false" hits="0"/>
+            <line number="105" branch="false" hits="0"/>
+            <line number="110" branch="false" hits="0"/>
+            <line number="111" branch="false" hits="0"/>
+            <line number="112" branch="false" hits="0"/>
+            <line number="113" branch="false" hits="0"/>
+            <line number="114" branch="false" hits="0"/>
+            <line number="115" branch="false" hits="0"/>
+            <line number="116" branch="false" hits="0"/>
+            <line number="117" branch="false" hits="0"/>
+            <line number="118" branch="false" hits="0"/>
+            <line number="119" branch="false" hits="0"/>
+            <line number="121" branch="false" hits="0"/>
+            <line number="122" branch="false" hits="0"/>
+            <line number="123" branch="false" hits="0"/>
+            <line number="124" branch="false" hits="0"/>
+            <line number="125" branch="false" hits="0"/>
+            <line number="126" branch="false" hits="0"/>
+            <line number="127" branch="false" hits="0"/>
+            <line number="128" branch="false" hits="0"/>
+            <line number="129" branch="false" hits="0"/>
+            <line number="130" branch="false" hits="0"/>
+            <line number="131" branch="false" hits="0"/>
+            <line number="132" branch="false" hits="0"/>
+            <line number="133" branch="false" hits="0"/>
+            <line number="134" branch="false" hits="0"/>
+            <line number="135" branch="false" hits="0"/>
+            <line number="136" branch="false" hits="0"/>
+            <line number="137" branch="false" hits="0"/>
+            <line number="138" branch="false" hits="0"/>
+            <line number="139" branch="false" hits="0"/>
+            <line number="140" branch="false" hits="0"/>
+            <line number="141" branch="false" hits="0"/>
+            <line number="142" branch="false" hits="0"/>
+            <line number="143" branch="false" hits="0"/>
+            <line number="144" branch="false" hits="0"/>
+            <line number="145" branch="false" hits="0"/>
+            <line number="146" branch="false" hits="0"/>
+            <line number="147" branch="false" hits="0"/>
+            <line number="148" branch="false" hits="0"/>
+            <line number="149" branch="false" hits="0"/>
+            <line number="150" branch="false" hits="0"/>
+            <line number="151" branch="false" hits="0"/>
+            <line number="152" branch="false" hits="0"/>
+            <line number="153" branch="false" hits="0"/>
+            <line number="154" branch="false" hits="0"/>
+            <line number="155" branch="false" hits="0"/>
+            <line number="156" branch="false" hits="0"/>
+            <line number="157" branch="false" hits="0"/>
+            <line number="158" branch="false" hits="0"/>
+            <line number="159" branch="false" hits="0"/>
+            <line number="160" branch="false" hits="0"/>
+            <line number="161" branch="false" hits="0"/>
+            <line number="162" branch="false" hits="0"/>
+            <line number="163" branch="false" hits="0"/>
+            <line number="164" branch="false" hits="0"/>
+            <line number="165" branch="false" hits="0"/>
+            <line number="166" branch="false" hits="0"/>
+            <line number="167" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="FattmerchantConfiguration" filename="fattmerchant-ios-sdk/FattmerchantConfiguration.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="32" branch="false" hits="0"/>
+            <line number="34" branch="false" hits="0"/>
+            <line number="35" branch="false" hits="0"/>
+            <line number="36" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="Networking" filename="fattmerchant-ios-sdk/Networking.swift" line-rate="0.6590909090909091" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="28" branch="false" hits="1"/>
+            <line number="29" branch="false" hits="1"/>
+            <line number="30" branch="false" hits="1"/>
+            <line number="32" branch="false" hits="1"/>
+            <line number="33" branch="false" hits="1"/>
+            <line number="34" branch="false" hits="1"/>
+            <line number="35" branch="false" hits="1"/>
+            <line number="36" branch="false" hits="1"/>
+            <line number="37" branch="false" hits="1"/>
+            <line number="38" branch="false" hits="1"/>
+            <line number="39" branch="false" hits="1"/>
+            <line number="40" branch="false" hits="1"/>
+            <line number="42" branch="false" hits="0"/>
+            <line number="43" branch="false" hits="0"/>
+            <line number="44" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
+            <line number="48" branch="false" hits="0"/>
+            <line number="50" branch="false" hits="0"/>
+            <line number="51" branch="false" hits="0"/>
+            <line number="52" branch="false" hits="0"/>
+            <line number="53" branch="false" hits="0"/>
+            <line number="55" branch="false" hits="0"/>
+            <line number="56" branch="false" hits="0"/>
+            <line number="57" branch="false" hits="0"/>
+            <line number="58" branch="false" hits="0"/>
+            <line number="60" branch="false" hits="1"/>
+            <line number="61" branch="false" hits="1"/>
+            <line number="62" branch="false" hits="1"/>
+            <line number="63" branch="false" hits="1"/>
+            <line number="64" branch="false" hits="1"/>
+            <line number="65" branch="false" hits="1"/>
+            <line number="66" branch="false" hits="1"/>
+            <line number="67" branch="false" hits="1"/>
+            <line number="68" branch="false" hits="1"/>
+            <line number="69" branch="false" hits="1"/>
+            <line number="70" branch="false" hits="0"/>
+            <line number="71" branch="false" hits="1"/>
+            <line number="72" branch="false" hits="1"/>
+            <line number="73" branch="false" hits="1"/>
+            <line number="74" branch="false" hits="1"/>
+            <line number="75" branch="false" hits="1"/>
+            <line number="76" branch="false" hits="1"/>
+            <line number="77" branch="false" hits="1"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+    <package name="fattmerchant-ios-sdk.Models" line-rate="0.1525423728813559" branch-rate="1.0000000000000000" complexity="0.0">
+      <classes>
+        <class name="BankAccount" filename="fattmerchant-ios-sdk/Models/BankAccount.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="40" branch="false" hits="0"/>
+            <line number="43" branch="false" hits="0"/>
+            <line number="44" branch="false" hits="0"/>
+            <line number="45" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
+            <line number="47" branch="false" hits="0"/>
+            <line number="48" branch="false" hits="0"/>
+            <line number="49" branch="false" hits="0"/>
+            <line number="50" branch="false" hits="0"/>
+            <line number="71" branch="false" hits="0"/>
+            <line number="72" branch="false" hits="0"/>
+            <line number="73" branch="false" hits="0"/>
+            <line number="74" branch="false" hits="0"/>
+            <line number="75" branch="false" hits="0"/>
             <line number="76" branch="false" hits="0"/>
             <line number="77" branch="false" hits="0"/>
             <line number="78" branch="false" hits="0"/>
@@ -1847,9 +2813,51 @@
             <line number="88" branch="false" hits="0"/>
             <line number="89" branch="false" hits="0"/>
             <line number="90" branch="false" hits="0"/>
-            <line number="91" branch="false" hits="0"/>
-            <line number="92" branch="false" hits="0"/>
-            <line number="93" branch="false" hits="0"/>
+            <line number="95" branch="false" hits="0"/>
+            <line number="96" branch="false" hits="0"/>
+            <line number="97" branch="false" hits="0"/>
+            <line number="98" branch="false" hits="0"/>
+            <line number="99" branch="false" hits="0"/>
+            <line number="100" branch="false" hits="0"/>
+            <line number="101" branch="false" hits="0"/>
+            <line number="102" branch="false" hits="0"/>
+            <line number="103" branch="false" hits="0"/>
+            <line number="104" branch="false" hits="0"/>
+            <line number="105" branch="false" hits="0"/>
+            <line number="106" branch="false" hits="0"/>
+            <line number="107" branch="false" hits="0"/>
+            <line number="108" branch="false" hits="0"/>
+            <line number="109" branch="false" hits="0"/>
+            <line number="110" branch="false" hits="0"/>
+            <line number="111" branch="false" hits="0"/>
+            <line number="112" branch="false" hits="0"/>
+            <line number="113" branch="false" hits="0"/>
+            <line number="114" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="ChargeRequest" filename="fattmerchant-ios-sdk/Models/ChargeRequest.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="30" branch="false" hits="0"/>
+            <line number="31" branch="false" hits="0"/>
+            <line number="32" branch="false" hits="0"/>
+            <line number="33" branch="false" hits="0"/>
+            <line number="34" branch="false" hits="0"/>
+            <line number="35" branch="false" hits="0"/>
+            <line number="36" branch="false" hits="0"/>
+            <line number="37" branch="false" hits="0"/>
+            <line number="38" branch="false" hits="0"/>
+          </lines>
+        </class>
+        <class name="CreditCard" filename="fattmerchant-ios-sdk/Models/CreditCard.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="71" branch="false" hits="0"/>
+            <line number="72" branch="false" hits="0"/>
+            <line number="73" branch="false" hits="0"/>
+            <line number="74" branch="false" hits="0"/>
+            <line number="75" branch="false" hits="0"/>
+            <line number="76" branch="false" hits="0"/>
             <line number="94" branch="false" hits="0"/>
             <line number="95" branch="false" hits="0"/>
             <line number="96" branch="false" hits="0"/>
@@ -1860,11 +2868,8 @@
             <line number="101" branch="false" hits="0"/>
             <line number="102" branch="false" hits="0"/>
             <line number="103" branch="false" hits="0"/>
+            <line number="104" branch="false" hits="0"/>
             <line number="105" branch="false" hits="0"/>
-            <line number="106" branch="false" hits="0"/>
-            <line number="107" branch="false" hits="0"/>
-            <line number="108" branch="false" hits="0"/>
-            <line number="109" branch="false" hits="0"/>
             <line number="110" branch="false" hits="0"/>
             <line number="111" branch="false" hits="0"/>
             <line number="112" branch="false" hits="0"/>
@@ -1877,580 +2882,40 @@
             <line number="119" branch="false" hits="0"/>
             <line number="120" branch="false" hits="0"/>
             <line number="121" branch="false" hits="0"/>
-            <line number="122" branch="false" hits="0"/>
-            <line number="123" branch="false" hits="0"/>
-            <line number="124" branch="false" hits="0"/>
-            <line number="125" branch="false" hits="0"/>
-            <line number="126" branch="false" hits="0"/>
-            <line number="127" branch="false" hits="0"/>
-            <line number="128" branch="false" hits="0"/>
-            <line number="129" branch="false" hits="0"/>
-            <line number="130" branch="false" hits="0"/>
-            <line number="131" branch="false" hits="0"/>
-            <line number="132" branch="false" hits="0"/>
-            <line number="133" branch="false" hits="0"/>
-            <line number="134" branch="false" hits="0"/>
-            <line number="135" branch="false" hits="0"/>
-            <line number="136" branch="false" hits="0"/>
-            <line number="137" branch="false" hits="0"/>
-            <line number="138" branch="false" hits="0"/>
-            <line number="139" branch="false" hits="0"/>
-            <line number="140" branch="false" hits="0"/>
-            <line number="141" branch="false" hits="0"/>
-            <line number="142" branch="false" hits="0"/>
-            <line number="143" branch="false" hits="0"/>
-            <line number="144" branch="false" hits="0"/>
-            <line number="145" branch="false" hits="0"/>
-            <line number="146" branch="false" hits="0"/>
-            <line number="147" branch="false" hits="0"/>
-            <line number="148" branch="false" hits="0"/>
-            <line number="149" branch="false" hits="0"/>
-            <line number="150" branch="false" hits="0"/>
-            <line number="151" branch="false" hits="0"/>
-            <line number="152" branch="false" hits="0"/>
-            <line number="153" branch="false" hits="0"/>
-            <line number="154" branch="false" hits="0"/>
-            <line number="155" branch="false" hits="0"/>
-            <line number="156" branch="false" hits="0"/>
-            <line number="157" branch="false" hits="0"/>
-            <line number="158" branch="false" hits="0"/>
-            <line number="159" branch="false" hits="0"/>
-            <line number="163" branch="false" hits="0"/>
-            <line number="164" branch="false" hits="0"/>
-            <line number="165" branch="false" hits="0"/>
-            <line number="166" branch="false" hits="0"/>
-            <line number="167" branch="false" hits="0"/>
-            <line number="168" branch="false" hits="0"/>
-            <line number="169" branch="false" hits="0"/>
-            <line number="170" branch="false" hits="0"/>
-            <line number="171" branch="false" hits="0"/>
-            <line number="172" branch="false" hits="0"/>
-            <line number="173" branch="false" hits="0"/>
-            <line number="174" branch="false" hits="0"/>
-            <line number="175" branch="false" hits="0"/>
-            <line number="176" branch="false" hits="0"/>
-            <line number="177" branch="false" hits="0"/>
-            <line number="178" branch="false" hits="0"/>
-            <line number="179" branch="false" hits="0"/>
-            <line number="185" branch="false" hits="0"/>
-            <line number="186" branch="false" hits="0"/>
-            <line number="187" branch="false" hits="0"/>
-            <line number="188" branch="false" hits="0"/>
-            <line number="189" branch="false" hits="0"/>
-            <line number="190" branch="false" hits="0"/>
-            <line number="191" branch="false" hits="0"/>
-            <line number="192" branch="false" hits="0"/>
-            <line number="193" branch="false" hits="0"/>
-            <line number="194" branch="false" hits="0"/>
-            <line number="195" branch="false" hits="0"/>
-            <line number="196" branch="false" hits="0"/>
-            <line number="197" branch="false" hits="0"/>
-            <line number="198" branch="false" hits="0"/>
-            <line number="199" branch="false" hits="0"/>
-            <line number="200" branch="false" hits="0"/>
-            <line number="201" branch="false" hits="0"/>
-            <line number="202" branch="false" hits="0"/>
-            <line number="203" branch="false" hits="0"/>
-            <line number="204" branch="false" hits="0"/>
-            <line number="205" branch="false" hits="0"/>
-            <line number="206" branch="false" hits="0"/>
-            <line number="208" branch="false" hits="0"/>
-            <line number="209" branch="false" hits="0"/>
-            <line number="210" branch="false" hits="0"/>
-            <line number="211" branch="false" hits="0"/>
-            <line number="212" branch="false" hits="0"/>
-            <line number="213" branch="false" hits="0"/>
-            <line number="214" branch="false" hits="0"/>
-            <line number="215" branch="false" hits="0"/>
-            <line number="216" branch="false" hits="0"/>
-            <line number="217" branch="false" hits="0"/>
-            <line number="219" branch="false" hits="0"/>
-            <line number="220" branch="false" hits="0"/>
-            <line number="221" branch="false" hits="0"/>
-            <line number="222" branch="false" hits="0"/>
-            <line number="223" branch="false" hits="0"/>
-            <line number="224" branch="false" hits="0"/>
-            <line number="225" branch="false" hits="0"/>
-            <line number="226" branch="false" hits="0"/>
-            <line number="227" branch="false" hits="0"/>
-            <line number="228" branch="false" hits="0"/>
-            <line number="229" branch="false" hits="0"/>
-            <line number="230" branch="false" hits="0"/>
-            <line number="231" branch="false" hits="0"/>
-            <line number="232" branch="false" hits="0"/>
-            <line number="233" branch="false" hits="0"/>
-            <line number="234" branch="false" hits="0"/>
-            <line number="235" branch="false" hits="0"/>
-            <line number="236" branch="false" hits="0"/>
-            <line number="237" branch="false" hits="0"/>
-            <line number="238" branch="false" hits="0"/>
-            <line number="239" branch="false" hits="0"/>
-            <line number="240" branch="false" hits="0"/>
-            <line number="241" branch="false" hits="0"/>
-            <line number="242" branch="false" hits="0"/>
-            <line number="243" branch="false" hits="0"/>
-            <line number="244" branch="false" hits="0"/>
-            <line number="245" branch="false" hits="0"/>
-            <line number="246" branch="false" hits="0"/>
-            <line number="247" branch="false" hits="0"/>
-            <line number="248" branch="false" hits="0"/>
-            <line number="249" branch="false" hits="0"/>
-            <line number="250" branch="false" hits="0"/>
-            <line number="251" branch="false" hits="0"/>
-            <line number="252" branch="false" hits="0"/>
-            <line number="253" branch="false" hits="0"/>
-            <line number="255" branch="false" hits="0"/>
-            <line number="256" branch="false" hits="0"/>
-            <line number="257" branch="false" hits="0"/>
-            <line number="258" branch="false" hits="0"/>
-            <line number="259" branch="false" hits="0"/>
-            <line number="260" branch="false" hits="0"/>
-            <line number="262" branch="false" hits="0"/>
-            <line number="263" branch="false" hits="0"/>
-            <line number="264" branch="false" hits="0"/>
-            <line number="266" branch="false" hits="0"/>
-            <line number="267" branch="false" hits="0"/>
-            <line number="268" branch="false" hits="0"/>
-            <line number="269" branch="false" hits="0"/>
-            <line number="270" branch="false" hits="0"/>
-            <line number="271" branch="false" hits="0"/>
-            <line number="272" branch="false" hits="0"/>
-            <line number="273" branch="false" hits="0"/>
-            <line number="274" branch="false" hits="0"/>
-            <line number="275" branch="false" hits="0"/>
-            <line number="276" branch="false" hits="0"/>
-            <line number="277" branch="false" hits="0"/>
-            <line number="278" branch="false" hits="0"/>
-            <line number="279" branch="false" hits="0"/>
-            <line number="280" branch="false" hits="0"/>
-            <line number="281" branch="false" hits="0"/>
-            <line number="283" branch="false" hits="0"/>
-            <line number="284" branch="false" hits="0"/>
-            <line number="285" branch="false" hits="0"/>
-            <line number="286" branch="false" hits="0"/>
-            <line number="287" branch="false" hits="0"/>
-            <line number="288" branch="false" hits="0"/>
-            <line number="289" branch="false" hits="0"/>
-            <line number="290" branch="false" hits="0"/>
-            <line number="291" branch="false" hits="0"/>
-            <line number="292" branch="false" hits="0"/>
-            <line number="293" branch="false" hits="0"/>
-            <line number="294" branch="false" hits="0"/>
-            <line number="295" branch="false" hits="0"/>
-            <line number="296" branch="false" hits="0"/>
-            <line number="297" branch="false" hits="0"/>
-            <line number="298" branch="false" hits="0"/>
-          </lines>
-        </class>
-      </classes>
-    </package>
-    <package name="fattmerchant-ios-sdk" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-      <classes>
-        <class name="FattmerchantApi" filename="fattmerchant-ios-sdk/FattmerchantApi.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
-            <line number="64" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="68" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="78" branch="false" hits="0"/>
-            <line number="79" branch="false" hits="0"/>
-            <line number="80" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
-            <line number="90" branch="false" hits="0"/>
-            <line number="91" branch="false" hits="0"/>
-            <line number="92" branch="false" hits="0"/>
-            <line number="93" branch="false" hits="0"/>
-            <line number="94" branch="false" hits="0"/>
-            <line number="103" branch="false" hits="0"/>
-            <line number="104" branch="false" hits="0"/>
-            <line number="105" branch="false" hits="0"/>
-            <line number="110" branch="false" hits="0"/>
-            <line number="111" branch="false" hits="0"/>
-            <line number="112" branch="false" hits="0"/>
-            <line number="113" branch="false" hits="0"/>
-            <line number="114" branch="false" hits="0"/>
-            <line number="115" branch="false" hits="0"/>
-            <line number="116" branch="false" hits="0"/>
-            <line number="117" branch="false" hits="0"/>
-            <line number="118" branch="false" hits="0"/>
-            <line number="119" branch="false" hits="0"/>
-            <line number="121" branch="false" hits="0"/>
-            <line number="122" branch="false" hits="0"/>
-            <line number="123" branch="false" hits="0"/>
-            <line number="124" branch="false" hits="0"/>
-            <line number="125" branch="false" hits="0"/>
-            <line number="126" branch="false" hits="0"/>
-            <line number="127" branch="false" hits="0"/>
-            <line number="128" branch="false" hits="0"/>
-            <line number="129" branch="false" hits="0"/>
-            <line number="130" branch="false" hits="0"/>
-            <line number="131" branch="false" hits="0"/>
-            <line number="132" branch="false" hits="0"/>
-            <line number="133" branch="false" hits="0"/>
-            <line number="134" branch="false" hits="0"/>
-            <line number="135" branch="false" hits="0"/>
-            <line number="136" branch="false" hits="0"/>
-            <line number="137" branch="false" hits="0"/>
-            <line number="138" branch="false" hits="0"/>
-            <line number="139" branch="false" hits="0"/>
-            <line number="140" branch="false" hits="0"/>
-            <line number="141" branch="false" hits="0"/>
-            <line number="142" branch="false" hits="0"/>
-            <line number="143" branch="false" hits="0"/>
-            <line number="144" branch="false" hits="0"/>
-            <line number="145" branch="false" hits="0"/>
-            <line number="146" branch="false" hits="0"/>
-            <line number="147" branch="false" hits="0"/>
-            <line number="148" branch="false" hits="0"/>
-            <line number="149" branch="false" hits="0"/>
-            <line number="150" branch="false" hits="0"/>
-            <line number="151" branch="false" hits="0"/>
-            <line number="152" branch="false" hits="0"/>
-            <line number="153" branch="false" hits="0"/>
-            <line number="154" branch="false" hits="0"/>
-            <line number="155" branch="false" hits="0"/>
-            <line number="156" branch="false" hits="0"/>
-            <line number="157" branch="false" hits="0"/>
-            <line number="158" branch="false" hits="0"/>
-            <line number="159" branch="false" hits="0"/>
-            <line number="160" branch="false" hits="0"/>
-            <line number="161" branch="false" hits="0"/>
-            <line number="162" branch="false" hits="0"/>
-            <line number="163" branch="false" hits="0"/>
-            <line number="164" branch="false" hits="0"/>
-            <line number="165" branch="false" hits="0"/>
-            <line number="166" branch="false" hits="0"/>
-            <line number="167" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="FattmerchantConfiguration" filename="fattmerchant-ios-sdk/FattmerchantConfiguration.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="32" branch="false" hits="0"/>
-            <line number="34" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
-            <line number="36" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="Networking" filename="fattmerchant-ios-sdk/Networking.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="28" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="30" branch="false" hits="0"/>
-            <line number="32" branch="false" hits="0"/>
-            <line number="33" branch="false" hits="0"/>
-            <line number="34" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
-            <line number="36" branch="false" hits="0"/>
-            <line number="37" branch="false" hits="0"/>
-            <line number="38" branch="false" hits="0"/>
-            <line number="39" branch="false" hits="0"/>
-            <line number="40" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="46" branch="false" hits="0"/>
-            <line number="47" branch="false" hits="0"/>
-            <line number="48" branch="false" hits="0"/>
-            <line number="50" branch="false" hits="0"/>
-            <line number="51" branch="false" hits="0"/>
-            <line number="52" branch="false" hits="0"/>
-            <line number="53" branch="false" hits="0"/>
-            <line number="55" branch="false" hits="0"/>
-            <line number="56" branch="false" hits="0"/>
-            <line number="57" branch="false" hits="0"/>
-            <line number="58" branch="false" hits="0"/>
-            <line number="60" branch="false" hits="0"/>
-            <line number="61" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
-            <line number="64" branch="false" hits="0"/>
-            <line number="65" branch="false" hits="0"/>
-            <line number="66" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="68" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="70" branch="false" hits="0"/>
-            <line number="71" branch="false" hits="0"/>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="74" branch="false" hits="0"/>
-            <line number="75" branch="false" hits="0"/>
-            <line number="76" branch="false" hits="0"/>
-            <line number="77" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="FattmerchantApi" filename="fattmerchant-ios-sdk/FattmerchantApi.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
-            <line number="64" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="68" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="78" branch="false" hits="0"/>
-            <line number="79" branch="false" hits="0"/>
-            <line number="80" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
-            <line number="90" branch="false" hits="0"/>
-            <line number="91" branch="false" hits="0"/>
-            <line number="92" branch="false" hits="0"/>
-            <line number="93" branch="false" hits="0"/>
-            <line number="94" branch="false" hits="0"/>
-            <line number="103" branch="false" hits="0"/>
-            <line number="104" branch="false" hits="0"/>
-            <line number="105" branch="false" hits="0"/>
-            <line number="110" branch="false" hits="0"/>
-            <line number="111" branch="false" hits="0"/>
-            <line number="112" branch="false" hits="0"/>
-            <line number="113" branch="false" hits="0"/>
-            <line number="114" branch="false" hits="0"/>
-            <line number="115" branch="false" hits="0"/>
-            <line number="116" branch="false" hits="0"/>
-            <line number="117" branch="false" hits="0"/>
-            <line number="118" branch="false" hits="0"/>
-            <line number="119" branch="false" hits="0"/>
-            <line number="121" branch="false" hits="0"/>
-            <line number="122" branch="false" hits="0"/>
-            <line number="123" branch="false" hits="0"/>
-            <line number="124" branch="false" hits="0"/>
-            <line number="125" branch="false" hits="0"/>
-            <line number="126" branch="false" hits="0"/>
-            <line number="127" branch="false" hits="0"/>
-            <line number="128" branch="false" hits="0"/>
-            <line number="129" branch="false" hits="0"/>
-            <line number="130" branch="false" hits="0"/>
-            <line number="131" branch="false" hits="0"/>
-            <line number="132" branch="false" hits="0"/>
-            <line number="133" branch="false" hits="0"/>
-            <line number="134" branch="false" hits="0"/>
-            <line number="135" branch="false" hits="0"/>
-            <line number="136" branch="false" hits="0"/>
-            <line number="137" branch="false" hits="0"/>
-            <line number="138" branch="false" hits="0"/>
-            <line number="139" branch="false" hits="0"/>
-            <line number="140" branch="false" hits="0"/>
-            <line number="141" branch="false" hits="0"/>
-            <line number="142" branch="false" hits="0"/>
-            <line number="143" branch="false" hits="0"/>
-            <line number="144" branch="false" hits="0"/>
-            <line number="145" branch="false" hits="0"/>
-            <line number="146" branch="false" hits="0"/>
-            <line number="147" branch="false" hits="0"/>
-            <line number="148" branch="false" hits="0"/>
-            <line number="149" branch="false" hits="0"/>
-            <line number="150" branch="false" hits="0"/>
-            <line number="151" branch="false" hits="0"/>
-            <line number="152" branch="false" hits="0"/>
-            <line number="153" branch="false" hits="0"/>
-            <line number="154" branch="false" hits="0"/>
-            <line number="155" branch="false" hits="0"/>
-            <line number="156" branch="false" hits="0"/>
-            <line number="157" branch="false" hits="0"/>
-            <line number="158" branch="false" hits="0"/>
-            <line number="159" branch="false" hits="0"/>
-            <line number="160" branch="false" hits="0"/>
-            <line number="161" branch="false" hits="0"/>
-            <line number="162" branch="false" hits="0"/>
-            <line number="163" branch="false" hits="0"/>
-            <line number="164" branch="false" hits="0"/>
-            <line number="165" branch="false" hits="0"/>
-            <line number="166" branch="false" hits="0"/>
-            <line number="167" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="FattmerchantConfiguration" filename="fattmerchant-ios-sdk/FattmerchantConfiguration.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="32" branch="false" hits="0"/>
-            <line number="34" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
-            <line number="36" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="Networking" filename="fattmerchant-ios-sdk/Networking.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="28" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
-            <line number="30" branch="false" hits="0"/>
-            <line number="32" branch="false" hits="0"/>
-            <line number="33" branch="false" hits="0"/>
-            <line number="34" branch="false" hits="0"/>
-            <line number="35" branch="false" hits="0"/>
-            <line number="36" branch="false" hits="0"/>
-            <line number="37" branch="false" hits="0"/>
-            <line number="38" branch="false" hits="0"/>
-            <line number="39" branch="false" hits="0"/>
-            <line number="40" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="46" branch="false" hits="0"/>
-            <line number="47" branch="false" hits="0"/>
-            <line number="48" branch="false" hits="0"/>
-            <line number="50" branch="false" hits="0"/>
-            <line number="51" branch="false" hits="0"/>
-            <line number="52" branch="false" hits="0"/>
-            <line number="53" branch="false" hits="0"/>
-            <line number="55" branch="false" hits="0"/>
-            <line number="56" branch="false" hits="0"/>
-            <line number="57" branch="false" hits="0"/>
-            <line number="58" branch="false" hits="0"/>
-            <line number="60" branch="false" hits="0"/>
-            <line number="61" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
-            <line number="64" branch="false" hits="0"/>
-            <line number="65" branch="false" hits="0"/>
-            <line number="66" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="68" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="70" branch="false" hits="0"/>
-            <line number="71" branch="false" hits="0"/>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="74" branch="false" hits="0"/>
-            <line number="75" branch="false" hits="0"/>
-            <line number="76" branch="false" hits="0"/>
-            <line number="77" branch="false" hits="0"/>
-          </lines>
-        </class>
-      </classes>
-    </package>
-    <package name="fattmerchant-ios-sdk.Models" line-rate="0.0142857142857143" branch-rate="1.0000000000000000" complexity="0.0">
-      <classes>
-        <class name="BankAccount" filename="fattmerchant-ios-sdk/Models/BankAccount.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="40" branch="false" hits="0"/>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="45" branch="false" hits="0"/>
-            <line number="46" branch="false" hits="0"/>
-            <line number="47" branch="false" hits="0"/>
-            <line number="48" branch="false" hits="0"/>
-            <line number="49" branch="false" hits="0"/>
-            <line number="50" branch="false" hits="0"/>
-            <line number="71" branch="false" hits="0"/>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="74" branch="false" hits="0"/>
-            <line number="75" branch="false" hits="0"/>
-            <line number="76" branch="false" hits="0"/>
-            <line number="77" branch="false" hits="0"/>
-            <line number="78" branch="false" hits="0"/>
-            <line number="79" branch="false" hits="0"/>
-            <line number="80" branch="false" hits="0"/>
-            <line number="81" branch="false" hits="0"/>
-            <line number="82" branch="false" hits="0"/>
-            <line number="83" branch="false" hits="0"/>
-            <line number="84" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
-            <line number="90" branch="false" hits="0"/>
-            <line number="95" branch="false" hits="0"/>
-            <line number="96" branch="false" hits="0"/>
-            <line number="97" branch="false" hits="0"/>
-            <line number="98" branch="false" hits="0"/>
-            <line number="99" branch="false" hits="0"/>
-            <line number="100" branch="false" hits="0"/>
-            <line number="101" branch="false" hits="0"/>
-            <line number="102" branch="false" hits="0"/>
-            <line number="103" branch="false" hits="0"/>
-            <line number="104" branch="false" hits="0"/>
-            <line number="105" branch="false" hits="0"/>
-            <line number="106" branch="false" hits="0"/>
-            <line number="107" branch="false" hits="0"/>
-            <line number="108" branch="false" hits="0"/>
-            <line number="109" branch="false" hits="0"/>
-            <line number="110" branch="false" hits="0"/>
-            <line number="111" branch="false" hits="0"/>
-            <line number="112" branch="false" hits="0"/>
-            <line number="113" branch="false" hits="0"/>
-            <line number="114" branch="false" hits="0"/>
-          </lines>
-        </class>
-        <class name="CreditCard" filename="fattmerchant-ios-sdk/Models/CreditCard.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
-          <methods/>
-          <lines>
-            <line number="39" branch="false" hits="0"/>
-            <line number="40" branch="false" hits="0"/>
-            <line number="41" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
-            <line number="64" branch="false" hits="0"/>
-            <line number="65" branch="false" hits="0"/>
-            <line number="66" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="68" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="70" branch="false" hits="0"/>
-            <line number="71" branch="false" hits="0"/>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="78" branch="false" hits="0"/>
-            <line number="79" branch="false" hits="0"/>
-            <line number="80" branch="false" hits="0"/>
-            <line number="81" branch="false" hits="0"/>
-            <line number="82" branch="false" hits="0"/>
-            <line number="83" branch="false" hits="0"/>
-            <line number="84" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="Merchant" filename="fattmerchant-ios-sdk/Models/Merchant.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="18" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="22" branch="false" hits="0"/>
-            <line number="23" branch="false" hits="0"/>
-            <line number="24" branch="false" hits="0"/>
-            <line number="25" branch="false" hits="0"/>
-            <line number="26" branch="false" hits="0"/>
-            <line number="27" branch="false" hits="0"/>
-            <line number="28" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
             <line number="30" branch="false" hits="0"/>
             <line number="31" branch="false" hits="0"/>
             <line number="32" branch="false" hits="0"/>
+            <line number="51" branch="false" hits="0"/>
+            <line number="52" branch="false" hits="0"/>
+            <line number="53" branch="false" hits="0"/>
+            <line number="54" branch="false" hits="0"/>
+            <line number="55" branch="false" hits="0"/>
+            <line number="56" branch="false" hits="0"/>
+            <line number="57" branch="false" hits="0"/>
+            <line number="58" branch="false" hits="0"/>
+            <line number="59" branch="false" hits="0"/>
+            <line number="60" branch="false" hits="0"/>
+            <line number="61" branch="false" hits="0"/>
+            <line number="62" branch="false" hits="0"/>
+            <line number="63" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="MobileReader" filename="fattmerchant-ios-sdk/Models/MobileReader.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="15" branch="false" hits="0"/>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="19" branch="false" hits="0"/>
+            <line number="38" branch="false" hits="0"/>
+            <line number="39" branch="false" hits="0"/>
+            <line number="40" branch="false" hits="0"/>
+            <line number="41" branch="false" hits="0"/>
+            <line number="42" branch="false" hits="0"/>
+            <line number="43" branch="false" hits="0"/>
+            <line number="44" branch="false" hits="0"/>
+            <line number="46" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="OmniException" filename="fattmerchant-ios-sdk/Models/OmniException.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
@@ -2518,80 +2983,98 @@
             <line number="114" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="CreditCard" filename="fattmerchant-ios-sdk/Models/CreditCard.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="ChargeRequest" filename="fattmerchant-ios-sdk/Models/ChargeRequest.swift" line-rate="0.8888888888888888" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="39" branch="false" hits="0"/>
-            <line number="40" branch="false" hits="0"/>
-            <line number="41" branch="false" hits="0"/>
-            <line number="42" branch="false" hits="0"/>
-            <line number="43" branch="false" hits="0"/>
-            <line number="44" branch="false" hits="0"/>
-            <line number="62" branch="false" hits="0"/>
-            <line number="63" branch="false" hits="0"/>
-            <line number="64" branch="false" hits="0"/>
-            <line number="65" branch="false" hits="0"/>
-            <line number="66" branch="false" hits="0"/>
-            <line number="67" branch="false" hits="0"/>
-            <line number="68" branch="false" hits="0"/>
-            <line number="69" branch="false" hits="0"/>
-            <line number="70" branch="false" hits="0"/>
-            <line number="71" branch="false" hits="0"/>
-            <line number="72" branch="false" hits="0"/>
-            <line number="73" branch="false" hits="0"/>
-            <line number="78" branch="false" hits="0"/>
-            <line number="79" branch="false" hits="0"/>
-            <line number="80" branch="false" hits="0"/>
-            <line number="81" branch="false" hits="0"/>
-            <line number="82" branch="false" hits="0"/>
-            <line number="83" branch="false" hits="0"/>
-            <line number="84" branch="false" hits="0"/>
-            <line number="85" branch="false" hits="0"/>
-            <line number="86" branch="false" hits="0"/>
-            <line number="87" branch="false" hits="0"/>
-            <line number="88" branch="false" hits="0"/>
-            <line number="89" branch="false" hits="0"/>
+            <line number="30" branch="false" hits="3"/>
+            <line number="31" branch="false" hits="3"/>
+            <line number="32" branch="false" hits="3"/>
+            <line number="33" branch="false" hits="3"/>
+            <line number="34" branch="false" hits="3"/>
+            <line number="35" branch="false" hits="3"/>
+            <line number="36" branch="false" hits="0"/>
+            <line number="37" branch="false" hits="3"/>
+            <line number="38" branch="false" hits="3"/>
+          </lines>
+        </class>
+        <class name="CreditCard" filename="fattmerchant-ios-sdk/Models/CreditCard.swift" line-rate="0.6000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+          <methods/>
+          <lines>
+            <line number="71" branch="false" hits="9"/>
+            <line number="72" branch="false" hits="9"/>
+            <line number="73" branch="false" hits="9"/>
+            <line number="74" branch="false" hits="9"/>
+            <line number="75" branch="false" hits="9"/>
+            <line number="76" branch="false" hits="9"/>
+            <line number="94" branch="false" hits="5"/>
+            <line number="95" branch="false" hits="5"/>
+            <line number="96" branch="false" hits="5"/>
+            <line number="97" branch="false" hits="5"/>
+            <line number="98" branch="false" hits="5"/>
+            <line number="99" branch="false" hits="5"/>
+            <line number="100" branch="false" hits="5"/>
+            <line number="101" branch="false" hits="5"/>
+            <line number="102" branch="false" hits="5"/>
+            <line number="103" branch="false" hits="5"/>
+            <line number="104" branch="false" hits="5"/>
+            <line number="105" branch="false" hits="5"/>
+            <line number="110" branch="false" hits="0"/>
+            <line number="111" branch="false" hits="0"/>
+            <line number="112" branch="false" hits="0"/>
+            <line number="113" branch="false" hits="0"/>
+            <line number="114" branch="false" hits="0"/>
+            <line number="115" branch="false" hits="0"/>
+            <line number="116" branch="false" hits="0"/>
+            <line number="117" branch="false" hits="0"/>
+            <line number="118" branch="false" hits="0"/>
+            <line number="119" branch="false" hits="0"/>
+            <line number="120" branch="false" hits="0"/>
+            <line number="121" branch="false" hits="0"/>
           </lines>
         </class>
         <class name="Merchant" filename="fattmerchant-ios-sdk/Models/Merchant.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="16" branch="false" hits="0"/>
-            <line number="17" branch="false" hits="0"/>
-            <line number="18" branch="false" hits="0"/>
-            <line number="20" branch="false" hits="0"/>
-            <line number="21" branch="false" hits="0"/>
-            <line number="22" branch="false" hits="0"/>
-            <line number="23" branch="false" hits="0"/>
-            <line number="24" branch="false" hits="0"/>
-            <line number="25" branch="false" hits="0"/>
-            <line number="26" branch="false" hits="0"/>
-            <line number="27" branch="false" hits="0"/>
-            <line number="28" branch="false" hits="0"/>
-            <line number="29" branch="false" hits="0"/>
             <line number="30" branch="false" hits="0"/>
             <line number="31" branch="false" hits="0"/>
             <line number="32" branch="false" hits="0"/>
+            <line number="51" branch="false" hits="0"/>
+            <line number="52" branch="false" hits="0"/>
+            <line number="53" branch="false" hits="0"/>
+            <line number="54" branch="false" hits="0"/>
+            <line number="55" branch="false" hits="0"/>
+            <line number="56" branch="false" hits="0"/>
+            <line number="57" branch="false" hits="0"/>
+            <line number="58" branch="false" hits="0"/>
+            <line number="59" branch="false" hits="0"/>
+            <line number="60" branch="false" hits="0"/>
+            <line number="61" branch="false" hits="0"/>
+            <line number="62" branch="false" hits="0"/>
+            <line number="63" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="MobileReader" filename="fattmerchant-ios-sdk/Models/MobileReader.swift" line-rate="0.7500000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="MobileReader" filename="fattmerchant-ios-sdk/Models/MobileReader.swift" line-rate="0.8750000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
-            <line number="15" branch="false" hits="2"/>
-            <line number="16" branch="false" hits="2"/>
-            <line number="17" branch="false" hits="2"/>
-            <line number="19" branch="false" hits="0"/>
+            <line number="38" branch="false" hits="36"/>
+            <line number="39" branch="false" hits="36"/>
+            <line number="40" branch="false" hits="36"/>
+            <line number="41" branch="false" hits="36"/>
+            <line number="42" branch="false" hits="36"/>
+            <line number="43" branch="false" hits="36"/>
+            <line number="44" branch="false" hits="36"/>
+            <line number="46" branch="false" hits="0"/>
           </lines>
         </class>
-        <class name="OmniException" filename="fattmerchant-ios-sdk/Models/OmniException.swift" line-rate="0.0000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
+        <class name="OmniException" filename="fattmerchant-ios-sdk/Models/OmniException.swift" line-rate="0.5000000000000000" branch-rate="1.0000000000000000" complexity="0.0">
           <methods/>
           <lines>
             <line number="19" branch="false" hits="0"/>
             <line number="20" branch="false" hits="0"/>
             <line number="21" branch="false" hits="0"/>
-            <line number="23" branch="false" hits="0"/>
-            <line number="24" branch="false" hits="0"/>
-            <line number="25" branch="false" hits="0"/>
+            <line number="23" branch="false" hits="3"/>
+            <line number="24" branch="false" hits="3"/>
+            <line number="25" branch="false" hits="3"/>
           </lines>
         </class>
       </classes>

--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		5993C2642077A687004DDA9F /* BankAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5993C2632077A687004DDA9F /* BankAccount.swift */; };
 		5993C2662077B4EE004DDA9F /* BankHolderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5993C2652077B4EE004DDA9F /* BankHolderType.swift */; };
 		5993C2682077B6B6004DDA9F /* PaymentMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5993C2672077B6B6004DDA9F /* PaymentMethodType.swift */; };
+		59F1FF3F24742F3F00019E06 /* TakeMobileReaderPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F1FF3E24742F3F00019E06 /* TakeMobileReaderPaymentTests.swift */; };
 		D702B7BD23C8D0DD00B8AB79 /* OmniApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = D702B7BC23C8D0DD00B8AB79 /* OmniApi.swift */; };
 		D702B7CC23C8F80200B8AB79 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5993C25B2076BD68004DDA9F /* PaymentMethod.swift */; };
 		D702B7CD23C8F80200B8AB79 /* CreditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5993C25D2076BD73004DDA9F /* CreditCard.swift */; };
@@ -207,6 +208,7 @@
 		5993C2632077A687004DDA9F /* BankAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccount.swift; sourceTree = "<group>"; };
 		5993C2652077B4EE004DDA9F /* BankHolderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankHolderType.swift; sourceTree = "<group>"; };
 		5993C2672077B6B6004DDA9F /* PaymentMethodType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodType.swift; sourceTree = "<group>"; };
+		59F1FF3E24742F3F00019E06 /* TakeMobileReaderPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeMobileReaderPaymentTests.swift; sourceTree = "<group>"; };
 		D702B7BC23C8D0DD00B8AB79 /* OmniApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmniApi.swift; sourceTree = "<group>"; };
 		D71B6F90239E971A007FB7C4 /* ChipDnaDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipDnaDriver.swift; sourceTree = "<group>"; };
 		D71B6F92239E9892007FB7C4 /* chipdna-bridging-header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "chipdna-bridging-header.h"; path = "fattmerchant-ios-sdk/chipdna-bridging-header.h"; sourceTree = SOURCE_ROOT; };
@@ -591,6 +593,7 @@
 				D783DAC32449F35E007C0A17 /* TakePaymentTests.swift */,
 				D783DAC5244CB409007C0A17 /* TokenizePaymentMethodTests.swift */,
 				D73BBCF6244D805C0052B525 /* DisconnectMobileReaderTests.swift */,
+				59F1FF3E24742F3F00019E06 /* TakeMobileReaderPaymentTests.swift */,
 			);
 			path = Usecase;
 			sourceTree = "<group>";
@@ -893,6 +896,7 @@
 				D7B7110523D35FD500EF98DB /* MobileReaderOne.swift in Sources */,
 				D7801BF2241F264400A93001 /* MockModelRepository.swift in Sources */,
 				D783DAC12449E905007C0A17 /* ChargeRequest.swift in Sources */,
+				59F1FF3F24742F3F00019E06 /* TakeMobileReaderPaymentTests.swift in Sources */,
 				D7C17B2D23EA010F0031D9BB /* MockDriver.swift in Sources */,
 				D7B7113C23D63B0D00EF98DB /* Environment.swift in Sources */,
 				D765D49A23CFC22600656040 /* PaymentMethodRepository.swift in Sources */,

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -241,40 +241,6 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
     }
   }
 
-  fileprivate func refund2(transaction: Transaction, completion: @escaping (TransactionResult) -> Void, error: @escaping (OmniException) -> Void) {
-
-    let request = TransactionRequest(amount: Amount(dollars: transaction.total!))
-
-    let requestParams = CCParameters(transactionRequest: request)
-    requestParams[CCParamTransactionType] = CCValueRefund
-    requestParams[CCParamSaleReference] = extractUserReference(from: transaction)!
-
-    chipDnaTransactionListener.detachFromChipDna()
-
-    chipDnaTransactionListener.onFinished = { result in
-
-      let success = result[CCParamTransactionResult] == CCValueApproved
-
-      var transactionResult = TransactionResult()
-      transactionResult.request = request
-      transactionResult.success = success
-      transactionResult.maskedPan = result[CCParamMaskedPan]
-      transactionResult.cardHolderFirstName = result[CCParamCardHolderFirstName]
-      transactionResult.cardHolderLastName = result[CCParamCardHolderLastName]
-      transactionResult.authCode = result[CCParamAuthCode]
-      transactionResult.cardType = result[CCParamCardSchemeId]?.lowercased()
-      transactionResult.userReference = result[CCParamUserReference]
-      transactionResult.transactionType = "refund"
-
-      completion(transactionResult)
-      return
-    }
-
-    chipDnaTransactionListener.bindToChipDna()
-
-    ChipDnaMobile.sharedInstance()?.startTransaction(requestParams)
-  }
-
   fileprivate func extractCardEaseReference(from transaction: Transaction) -> String? {
     return transaction.meta?["cardEaseReference"]
   }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -102,7 +102,7 @@ class TakeMobileReaderPayment {
     }
   }
 
-  fileprivate func createTransaction(result: TransactionResult, paymentMethod: PaymentMethod, customer: Customer, invoice: Invoice, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Transaction) -> Void) {
+  internal func createTransaction(result: TransactionResult, paymentMethod: PaymentMethod, customer: Customer, invoice: Invoice, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Transaction) -> Void) {
     let transactionToCreate = Transaction()
 
     guard let paymentMethodId = paymentMethod.id else {
@@ -155,6 +155,8 @@ class TakeMobileReaderPayment {
     transactionToCreate.customerId = customerId
     transactionToCreate.invoiceId = invoiceId
     transactionToCreate.response = gatewayResponseJson
+    transactionToCreate.token = result.externalId
+
     transactionRepository.create(model: transactionToCreate, completion: completion, error: failure)
   }
 

--- a/fattmerchant-ios-sdk/Models/Transaction.swift
+++ b/fattmerchant-ios-sdk/Models/Transaction.swift
@@ -74,6 +74,12 @@ public class Transaction: Model {
   /// Typically "card" or "bank"
   public var method: String?
 
+  /// The transaction 'token'
+  ///
+  /// This is technically the id of the transaction in a foreign platform. The Omni API expects this value when we
+  /// create a transaction, but we will likely never receive it.
+  internal var token: String?
+
   var authId: String?
   var gateway: String?
   var gatewayId: String?
@@ -91,6 +97,5 @@ public class Transaction: Model {
   var source: String?
   var sourceIp: String?
   var response: JSONValue?
-  var spreedlyToken: String?
   var updatedAt: String?
 }

--- a/fattmerchant_ios_sdkTests/Mock/MockModelRepository.swift
+++ b/fattmerchant_ios_sdkTests/Mock/MockModelRepository.swift
@@ -8,26 +8,42 @@
 
 import Foundation
 
+internal var modelStore: [String: Model] = [:]
+
 extension ModelRepository {
+
+  func uniqueId() -> String {
+    return UUID().uuidString
+  }
 
   func create(model: OmniModel, completion: @escaping CompletionHandler, error: @escaping ErrorHandler) {
     var m = model
-    m.id = "generated_id_123"
+    let id = uniqueId()
+    m.id = id
+    modelStore[id] = m
     completion(m)
   }
 
   func update(model: OmniModel, id: String, completion: @escaping CompletionHandler, error: @escaping ErrorHandler) {
     var m = model
-    m.id = "generated_id_123"
+    m.id = id
+    modelStore[id] = m
     completion(m)
   }
 
   func delete(model: OmniModel, completion: @escaping EmptyCompletionHandler, error: @escaping ErrorHandler) {
+    if let id = model.id {
+      modelStore.removeValue(forKey: id)
+    }
     completion()
   }
 
   func getById(id: String, completion: @escaping CompletionHandler, error: @escaping ErrorHandler) {
-    fatalError("Need to implement this")
+    if let model = modelStore[id] as? Self.OmniModel {
+      completion(model)
+    } else {
+      error(OmniApi.OmniNetworkingException.unknown("Model not found"))
+    }
   }
 
   func getList(completion: @escaping (PaginatedData<OmniModel>) -> Void, error: @escaping ErrorHandler) {

--- a/fattmerchant_ios_sdkTests/Usecase/TakeMobileReaderPaymentTests.swift
+++ b/fattmerchant_ios_sdkTests/Usecase/TakeMobileReaderPaymentTests.swift
@@ -1,0 +1,89 @@
+//
+//  TakeMobileReaderTests.swift
+//  FattmerchantTests
+//
+//  Created by Tulio Troncoso on 5/19/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+class TakeMobileReaderPaymentTests: XCTestCase {
+
+  var mockOmniApi: MockOmniApi = MockOmniApi()
+  var mobileReaderDriverRepo: MobileReaderDriverRepository!
+  var invoiceRepo: InvoiceRepository!
+  var customerRepo: CustomerRepository!
+  var paymentMethodRepo: PaymentMethodRepository!
+  var transactionRepo: TransactionRepository!
+
+  override func setUp() {
+    invoiceRepo = InvoiceRepository(omniApi: mockOmniApi)
+    customerRepo = CustomerRepository(omniApi: mockOmniApi)
+    paymentMethodRepo = PaymentMethodRepository(omniApi: mockOmniApi)
+    transactionRepo = TransactionRepository(omniApi: mockOmniApi)
+    mobileReaderDriverRepo = MobileReaderDriverRepository()
+  }
+
+  func testCanTakeMobileReaderPayment() {
+    let transactionCompleted = expectation(description: "Transaction was successfully completed")
+
+    let transactionRequest = TransactionRequest(amount: Amount(cents: 1), tokenize: true)
+    TakeMobileReaderPayment(
+      mobileReaderDriverRepository: mobileReaderDriverRepo,
+      invoiceRepository: invoiceRepo,
+      customerRepository: customerRepo,
+      paymentMethodRepository: paymentMethodRepo,
+      transactionRepository: transactionRepo,
+      request: transactionRequest
+    ).start(completion: { completedTransaction in
+      transactionCompleted.fulfill()
+    }) { exception in
+      XCTFail("Transaction failed")
+    }
+
+    wait(for: [transactionCompleted], timeout: 10.0)
+  }
+
+  func testCreateTransactionIsCreatedWithToken() {
+    let transactionRequest = TransactionRequest(amount: Amount(cents: 1), tokenize: true)
+    let job = TakeMobileReaderPayment(
+      mobileReaderDriverRepository: mobileReaderDriverRepo,
+      invoiceRepository: invoiceRepo,
+      customerRepository: customerRepo,
+      paymentMethodRepository: paymentMethodRepo,
+      transactionRepository: transactionRepo,
+      request: transactionRequest
+    )
+
+    // Verify that the externalId is put in the transaction
+    let transactionHasExternalId = expectation(description: "Transaction has external id")
+    let paymentMethod = PaymentMethod()
+    paymentMethod.id = "payment-method-id"
+
+    let customer = Customer()
+    customer.id = "customer-id"
+
+    let invoice = Invoice()
+    invoice.id = "invoice-id"
+
+    var result = TransactionResult()
+    result.externalId = "externalId"
+    result.maskedPan = "41111111111111111"
+
+    job.createTransaction(result: result,
+                          paymentMethod: paymentMethod,
+                          customer: customer,
+                          invoice: invoice,
+                          { exception in
+                            XCTFail()
+                          }, { transaction in
+                            XCTAssertEqual(transaction.token, result.externalId)
+                            transactionHasExternalId.fulfill()
+                          })
+
+    wait(for: [transactionHasExternalId], timeout: 10.0)
+  }
+
+}


### PR DESCRIPTION
## What is this?
In order for Omni to be be able to refund a transaction done using the CPSDK, we need to tell Omni the id of that transaction. Omni will require that we pass this in as a `token` when we POST the transaction.

## What did I do?
- Added the `token` field to the Transaction model
- Made ChipDna transactions put the token in the Transaction model
- Wrote tests