### PR TITLE
[PHX-392] Collect card expiration dates

### DIFF
--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		591C20A2206EB26700C848DA /* FattmerchantIosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C20A1206EB26700C848DA /* FattmerchantIosTests.swift */; };
+		597BEA4B2480C4C9009319D6 /* TransactionGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA4A2480C4C9009319D6 /* TransactionGateway.swift */; };
+		597BEA4D2480D892009319D6 /* ChipDnaXMLTransactionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA4C2480D892009319D6 /* ChipDnaXMLTransactionParser.swift */; };
+		597BEA4E2480D892009319D6 /* ChipDnaXMLTransactionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA4C2480D892009319D6 /* ChipDnaXMLTransactionParser.swift */; };
+		597BEA5124851B7D009319D6 /* ChipDnaXMLTransactionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA5024851B7D009319D6 /* ChipDnaXMLTransactionParserTests.swift */; };
+		597BEA5324851BA9009319D6 /* ChipDnaTransctionXMLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA5224851BA9009319D6 /* ChipDnaTransctionXMLResponse.swift */; };
 		5993C25A2076BD16004DDA9F /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5993C2592076BD16004DDA9F /* Networking.swift */; };
 		5993C25C2076BD68004DDA9F /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5993C25B2076BD68004DDA9F /* PaymentMethod.swift */; };
 		5993C25E2076BD73004DDA9F /* CreditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5993C25D2076BD73004DDA9F /* CreditCard.swift */; };
@@ -198,6 +203,10 @@
 		591C209F206EB26600C848DA /* FattmerchantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FattmerchantTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		591C20A1206EB26700C848DA /* FattmerchantIosTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FattmerchantIosTests.swift; sourceTree = "<group>"; };
 		591C20A3206EB26700C848DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		597BEA4A2480C4C9009319D6 /* TransactionGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionGateway.swift; sourceTree = "<group>"; };
+		597BEA4C2480D892009319D6 /* ChipDnaXMLTransactionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipDnaXMLTransactionParser.swift; sourceTree = "<group>"; };
+		597BEA5024851B7D009319D6 /* ChipDnaXMLTransactionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipDnaXMLTransactionParserTests.swift; sourceTree = "<group>"; };
+		597BEA5224851BA9009319D6 /* ChipDnaTransctionXMLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipDnaTransctionXMLResponse.swift; sourceTree = "<group>"; };
 		5984E3F5207E872E002A6F73 /* Tokenization.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Tokenization.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5993C2592076BD16004DDA9F /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
 		5993C25B2076BD68004DDA9F /* PaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethod.swift; sourceTree = "<group>"; };
@@ -397,6 +406,15 @@
 				D7692F1823E4B00500CB0954 /* OmniTest.swift */,
 			);
 			path = fattmerchant_ios_sdkTests;
+			sourceTree = "<group>";
+		};
+		597BEA4F24851B68009319D6 /* ChipDna */ = {
+			isa = PBXGroup;
+			children = (
+				597BEA5024851B7D009319D6 /* ChipDnaXMLTransactionParserTests.swift */,
+				597BEA5224851BA9009319D6 /* ChipDnaTransctionXMLResponse.swift */,
+			);
+			path = ChipDna;
 			sourceTree = "<group>";
 		};
 		5993C2F6207D0402004DDA9F /* Models */ = {
@@ -604,6 +622,8 @@
 				D79308CA23D229420066FCA2 /* ChipDnaUtils.swift */,
 				D79308CF23D22D900066FCA2 /* ChipDnaTransactionListener.swift */,
 				D79308D123D22F480066FCA2 /* ChipDnaTransactionUserReference.swift */,
+				597BEA4A2480C4C9009319D6 /* TransactionGateway.swift */,
+				597BEA4C2480D892009319D6 /* ChipDnaXMLTransactionParser.swift */,
 			);
 			path = ChipDna;
 			sourceTree = "<group>";
@@ -627,6 +647,7 @@
 		D7B7110123D35F9000EF98DB /* Cardpresent */ = {
 			isa = PBXGroup;
 			children = (
+				597BEA4F24851B68009319D6 /* ChipDna */,
 				D7692F2323E4B6BA00CB0954 /* MockMobileReaderDriverRepository.swift */,
 				D7D2C51C23F203CF001733A2 /* RefundMobileReaderTransactionTests.swift */,
 			);
@@ -831,6 +852,7 @@
 				D765D47C23CCBB0500656040 /* ModelRepository.swift in Sources */,
 				5993C2642077A687004DDA9F /* BankAccount.swift in Sources */,
 				D7A28D642436278600FC8872 /* TokenizePaymentMethod.swift in Sources */,
+				597BEA4B2480C4C9009319D6 /* TransactionGateway.swift in Sources */,
 				D783DAC02449E905007C0A17 /* ChargeRequest.swift in Sources */,
 				D765D46923CC467100656040 /* Model.swift in Sources */,
 				D7801BF4241F26E200A93001 /* ModelRepository+DefaultImpl.swift in Sources */,
@@ -852,6 +874,7 @@
 				D79308AA23D0A9FB0066FCA2 /* TransactionRequest.swift in Sources */,
 				5993C2622076BD9B004DDA9F /* FattmerchantConfiguration.swift in Sources */,
 				D79308B823D0AC3A0066FCA2 /* ConnectMobileReader.swift in Sources */,
+				597BEA4D2480D892009319D6 /* ChipDnaXMLTransactionParser.swift in Sources */,
 				D781037F23D9F85100256F2F /* PaginatedData.swift in Sources */,
 				D765D46623CC465800656040 /* Customer.swift in Sources */,
 				D7B7113B23D63B0D00EF98DB /* Environment.swift in Sources */,
@@ -893,6 +916,7 @@
 				D78FA933240EF48B00398D81 /* SignatureProviding.swift in Sources */,
 				D7801BF2241F264400A93001 /* MockModelRepository.swift in Sources */,
 				D783DAC12449E905007C0A17 /* ChargeRequest.swift in Sources */,
+				597BEA5124851B7D009319D6 /* ChipDnaXMLTransactionParserTests.swift in Sources */,
 				59F1FF3F24742F3F00019E06 /* TakeMobileReaderPaymentTests.swift in Sources */,
 				D7C17B2D23EA010F0031D9BB /* MockDriver.swift in Sources */,
 				D7B7113C23D63B0D00EF98DB /* Environment.swift in Sources */,
@@ -903,6 +927,7 @@
 				D783DAC6244CB409007C0A17 /* TokenizePaymentMethodTests.swift in Sources */,
 				D765D46A23CC467100656040 /* Model.swift in Sources */,
 				D7C17B2623E4BA200031D9BB /* RefundMobileReaderTransaction.swift in Sources */,
+				597BEA4E2480D892009319D6 /* ChipDnaXMLTransactionParser.swift in Sources */,
 				D7720E47241760720064DBDC /* FattmerchantApi.swift in Sources */,
 				D7C17B2223E4BA200031D9BB /* ConnectMobileReader.swift in Sources */,
 				D702B7CF23C8F80200B8AB79 /* BankHolderType.swift in Sources */,
@@ -924,6 +949,7 @@
 				D7801BFF241F303600A93001 /* MockPaymentMethodRepository.swift in Sources */,
 				591C20A2206EB26700C848DA /* FattmerchantIosTests.swift in Sources */,
 				D7692F2423E4B6BA00CB0954 /* MockMobileReaderDriverRepository.swift in Sources */,
+				597BEA5324851BA9009319D6 /* ChipDnaTransctionXMLResponse.swift in Sources */,
 				D7D2C51E23F203F8001733A2 /* RefundMobileReaderTransactionTests.swift in Sources */,
 				D79308A023D0A1B50066FCA2 /* AmountTests.swift in Sources */,
 				D7692F1A23E4B03200CB0954 /* Omni.swift in Sources */,

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaXMLTransactionParser.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaXMLTransactionParser.swift
@@ -1,0 +1,104 @@
+//
+//  ChipDnaXMLTransactionParser.swift
+//  fattmerchant-ios-sdk
+//
+//  Created by Tulio Troncoso on 5/29/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+/// Parses information from a chipdna transaction formatted in XML
+class ChipDnaXMLTransactionParser: NSObject, XMLParserDelegate {
+
+  /// The expiration date of the card used for the transaction
+  var ccExpirationDate: String?
+
+  /// The value of the element that the parser is currently parsing
+  var currentValue: String = ""
+
+  /// The name of the element that the parser is currently parsing
+  var currentElementName: String = ""
+
+  /// The ID of the transaction we intend to parser out of the XML
+  var targetTransactionId: String = ""
+
+  /// `true` when parser element is within the target transaction. `false` otherwise
+  ///
+  /// The XML can have more objects than the target transaction
+  var parsingTargetTransaction: Bool = false
+
+  /// The XMLParser doing the parsing work
+  internal var parser: XMLParser?
+
+  /// A block to run once finished
+  var completion: ((String?) -> Void)?
+
+  /// Parses the expiration date from the XML
+  /// - Parameters:
+  ///   - xml: an xml-formatted Transaction from Transaction Gateway
+  ///   - completion: a block to run once finished. If the expiration date was retrieved, it is passed here. Nil
+  ///   otherwise
+  internal func parseExpirationDate(from transactionXml: Data, transactionId: String, completion: @escaping (String?) -> Void) {
+    self.completion = completion
+
+    // Make sure transaction id is not empty
+    guard !transactionId.isEmpty else {
+      completion(nil)
+      return
+    }
+
+    // Set the target transaction id
+    targetTransactionId = transactionId
+
+    // Create parser
+    let parser = XMLParser(data: transactionXml)
+    self.parser = parser
+    parser.delegate = self
+    parser.parse()
+  }
+
+  /// Stops the parsing and executes the completion block
+  func finish() {
+    parser?.abortParsing()
+    completion?(ccExpirationDate)
+  }
+
+  func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?,
+              qualifiedName qName: String?, attributes attributeDict: [String: String] = [:]) {
+    currentElementName = elementName
+    currentValue = ""
+  }
+
+  func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
+    // If we finished parsing a transaction and we were parsing the target transaction, then finish
+    if currentElementName == "transaction" && parsingTargetTransaction {
+      finish()
+      return
+    }
+
+    // If we finished parsing a transaction id, then check if this transaction id corresponds to the target transaction
+    if currentElementName == "transaction_id" {
+      parsingTargetTransaction = currentValue == targetTransactionId
+      return
+    }
+
+    // Make sure we are parsing the target transaction. We don't care about the other objects
+    guard parsingTargetTransaction else {
+      return
+    }
+
+    if currentElementName == "cc_exp" {
+      ccExpirationDate = currentValue
+      return
+    }
+  }
+
+  func parser(_ parser: XMLParser, foundCharacters string: String) {
+    currentValue += string
+  }
+
+  func parserDidEndDocument(_ parser: XMLParser) {
+    finish()
+  }
+}

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/TransactionGateway.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/TransactionGateway.swift
@@ -1,0 +1,42 @@
+//
+//  TransactionGateway.swift
+//  Fattmerchant
+//
+//  Created by Tulio Troncoso on 5/29/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+/// Communicates with Transaction Gateway via the Direct Post API
+/// https://fattmerchant.transactiongateway.com/merchants/resources/integration/integration_portal.php
+internal class TransactionGateway {
+
+  /// The base url of Transaction Gateway
+  static let baseUrl = "https://secure.nmi.com/api/query.php"
+
+  /// Fetches the CCExpiration for a transaction from TransactionGateway
+  /// - Parameters:
+  ///   - transactionId: the id of the Transaction
+  ///   - securityKey: authentication for Transaction Gateway
+  ///   - completion: a block to run once finished. Gets the cc expiration, if found
+  static func getTransactionCcExpiration(securityKey: String, transactionId: String, completion: @escaping (String?) -> Void) {
+    let session = URLSession(configuration: URLSessionConfiguration.default)
+    let url = URL(string: "\(baseUrl)?security_key=\(securityKey)&transaction_id=\(transactionId)")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+
+    let dataTask = session.dataTask(with: request) { (data, _, error) in
+      guard error == nil, let data = data else {
+        completion(nil)
+        return
+      }
+
+      let parser = ChipDnaXMLTransactionParser()
+      parser.parseExpirationDate(from: data, transactionId: transactionId, completion: completion)
+    }
+
+    dataTask.resume()
+  }
+
+}

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
@@ -45,6 +45,9 @@ struct TransactionResult {
   /** VISA, Mastercard, JCB, etc */
   var cardType: String?
 
+  /// The expiration date of the card in 'mmyy' format
+  var cardExpiration: String?
+
   /** A user-defined string used to refer to the transaction */
   var userReference: String?
 

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -239,6 +239,7 @@ class TakeMobileReaderPayment {
       return
     }
 
+    paymentMethodToCreate.cardExp = result.cardExpiration
     paymentMethodToCreate.customerId = customerId
     paymentMethodToCreate.method = PaymentMethodType.card
     paymentMethodToCreate.cardLastFour = lastFour
@@ -258,6 +259,9 @@ class TakeMobileReaderPayment {
   }
 
   fileprivate func createCustomer(_ transactionResult: TransactionResult, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Customer) -> Void) {
+
+    // Insert the matching logic
+
     let customerToCreate = Customer()
     customerToCreate.firstname = transactionResult.cardHolderFirstName ?? "SWIPE"
     customerToCreate.lastname = transactionResult.cardHolderLastName ?? "CUSTOMER"

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -259,9 +259,6 @@ class TakeMobileReaderPayment {
   }
 
   fileprivate func createCustomer(_ transactionResult: TransactionResult, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Customer) -> Void) {
-
-    // Insert the matching logic
-
     let customerToCreate = Customer()
     customerToCreate.firstname = transactionResult.cardHolderFirstName ?? "SWIPE"
     customerToCreate.lastname = transactionResult.cardHolderLastName ?? "CUSTOMER"

--- a/fattmerchant_ios_sdkTests/Cardpresent/ChipDna/ChipDnaTransctionXMLResponse.swift
+++ b/fattmerchant_ios_sdkTests/Cardpresent/ChipDna/ChipDnaTransctionXMLResponse.swift
@@ -1,0 +1,221 @@
+//
+//  ChipDnaTransctionXML.swift
+//  FattmerchantTests
+//
+//  Created by Tulio Troncoso on 6/1/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+/// A sample transaction xml response from ChipDna
+class ChipDnaTransactionXmlResponse {
+
+  /// The id of the transaction within the XML
+  static let transactionId: String = "5393522748"
+
+  /// The expiration date of the credit card used for the transaction
+  static let ccExpiration: String = "0324"
+
+  /// The XML response string
+  static let xml =
+  """
+  <nm_response>
+    <transaction>
+      <transaction_id>5393522748</transaction_id>
+      <partial_payment_id></partial_payment_id>
+      <partial_payment_balance></partial_payment_balance>
+      <platform_id>db44f918-27a1-ea11-80c0-0050568f0f14</platform_id>
+      <transaction_type>cc</transaction_type>
+      <condition>pendingsettlement</condition>
+      <order_id>CDM-05/28/20, 17:06:30</order_id>
+      <authorization_code>210714</authorization_code>
+      <ponumber></ponumber>
+      <order_description></order_description>
+      <first_name>A GIFT FOR</first_name>
+      <last_name>YOU</last_name>
+      <address_1></address_1>
+      <address_2></address_2>
+      <company></company>
+      <city></city>
+      <state></state>
+      <postal_code></postal_code>
+      <country></country>
+      <email></email>
+      <phone></phone>
+      <fax></fax>
+      <cell_phone></cell_phone>
+      <customertaxid></customertaxid>
+      <customerid>1436656942</customerid>
+      <website></website>
+      <shipping_first_name></shipping_first_name>
+      <shipping_last_name></shipping_last_name>
+      <shipping_address_1></shipping_address_1>
+      <shipping_address_2></shipping_address_2>
+      <shipping_company></shipping_company>
+      <shipping_city></shipping_city>
+      <shipping_state></shipping_state>
+      <shipping_postal_code></shipping_postal_code>
+      <shipping_country></shipping_country>
+      <shipping_email></shipping_email>
+      <shipping_carrier></shipping_carrier>
+      <tracking_number></tracking_number>
+      <shipping_date></shipping_date>
+      <shipping>0.00</shipping>
+      <shipping_phone></shipping_phone>
+      <cc_number>5xxxxxxxxxxx1860</cc_number>
+      <cc_hash>d58953a56ffa0d28cf15a0821124617d</cc_hash>
+      <cc_exp>0324</cc_exp>
+      <cavv></cavv>
+      <cavv_result></cavv_result>
+      <xid></xid>
+      <eci></eci>
+      <directory_server_id></directory_server_id>
+      <three_ds_version></three_ds_version>
+      <avs_response></avs_response>
+      <csc_response></csc_response>
+      <cardholder_auth></cardholder_auth>
+      <cc_start_date></cc_start_date>
+      <cc_issue_number></cc_issue_number>
+      <check_account></check_account>
+      <check_hash></check_hash>
+      <check_aba></check_aba>
+      <check_name></check_name>
+      <account_holder_type></account_holder_type>
+      <account_type></account_type>
+      <sec_code></sec_code>
+      <drivers_license_number></drivers_license_number>
+      <drivers_license_state></drivers_license_state>
+      <drivers_license_dob></drivers_license_dob>
+      <social_security_number></social_security_number>
+      <processor_id>pftestmiura</processor_id>
+      <tax>0.00</tax>
+      <currency>USD</currency>
+      <surcharge></surcharge>
+      <tip></tip>
+      <card_balance></card_balance>
+      <card_available_balance></card_available_balance>
+      <entry_mode>Swiped</entry_mode>
+      <cc_bin>516488</cc_bin>
+      <cc_type>Mastercard</cc_type>
+      <signature_image></signature_image>
+      <action>
+        <amount>0.01</amount>
+        <action_type>sale</action_type>
+        <date>20200528210637</date>
+        <success>1</success>
+        <ip_address>97.71.146.67</ip_address>
+        <source>api</source>
+        <api_method></api_method>
+        <username>pftest</username>
+        <response_text></response_text>
+        <batch_id>0</batch_id>
+        <processor_batch_id></processor_batch_id>
+        <response_code>0</response_code>
+        <processor_response_text></processor_response_text>
+        <processor_response_code></processor_response_code>
+        <device_license_number></device_license_number>
+        <device_nickname></device_nickname>
+      </action>
+    </transaction>
+    <transaction>
+      <transaction_id>5393534406</transaction_id>
+      <partial_payment_id></partial_payment_id>
+      <partial_payment_balance></partial_payment_balance>
+      <platform_id>c928f7e4-27a1-ea11-80c0-0050568f0f14</platform_id>
+      <transaction_type>cc</transaction_type>
+      <condition>pendingsettlement</condition>
+      <order_id></order_id>
+      <authorization_code>042196</authorization_code>
+      <ponumber></ponumber>
+      <order_description></order_description>
+      <first_name>A GIFT FOR</first_name>
+      <last_name>YOU</last_name>
+      <address_1></address_1>
+      <address_2></address_2>
+      <company></company>
+      <city></city>
+      <state></state>
+      <postal_code></postal_code>
+      <country></country>
+      <email></email>
+      <phone></phone>
+      <fax></fax>
+      <cell_phone></cell_phone>
+      <customertaxid></customertaxid>
+      <customerid></customerid>
+      <website></website>
+      <shipping_first_name></shipping_first_name>
+      <shipping_last_name></shipping_last_name>
+      <shipping_address_1></shipping_address_1>
+      <shipping_address_2></shipping_address_2>
+      <shipping_company></shipping_company>
+      <shipping_city></shipping_city>
+      <shipping_state></shipping_state>
+      <shipping_postal_code></shipping_postal_code>
+      <shipping_country></shipping_country>
+      <shipping_email></shipping_email>
+      <shipping_carrier></shipping_carrier>
+      <tracking_number></tracking_number>
+      <shipping_date></shipping_date>
+      <shipping>0.00</shipping>
+      <shipping_phone></shipping_phone>
+      <cc_number>5xxxxxxxxxxx1860</cc_number>
+      <cc_hash>d58953a56ffa0d28cf15a0821124617d</cc_hash>
+      <cc_exp>0324</cc_exp>
+      <cavv></cavv>
+      <cavv_result></cavv_result>
+      <xid></xid>
+      <eci></eci>
+      <directory_server_id></directory_server_id>
+      <three_ds_version></three_ds_version>
+      <avs_response></avs_response>
+      <csc_response></csc_response>
+      <cardholder_auth></cardholder_auth>
+      <cc_start_date></cc_start_date>
+      <cc_issue_number></cc_issue_number>
+      <check_account></check_account>
+      <check_hash></check_hash>
+      <check_aba></check_aba>
+      <check_name></check_name>
+      <account_holder_type></account_holder_type>
+      <account_type></account_type>
+      <sec_code></sec_code>
+      <drivers_license_number></drivers_license_number>
+      <drivers_license_state></drivers_license_state>
+      <drivers_license_dob></drivers_license_dob>
+      <social_security_number></social_security_number>
+      <processor_id>pftestmiura</processor_id>
+      <tax>0.00</tax>
+      <currency>USD</currency>
+      <surcharge></surcharge>
+      <tip></tip>
+      <card_balance></card_balance>
+      <card_available_balance></card_available_balance>
+      <entry_mode>Keyed</entry_mode>
+      <original_transaction_id>5393522748</original_transaction_id>
+      <cc_bin>516488</cc_bin>
+      <cc_type>Mastercard</cc_type>
+      <signature_image></signature_image>
+      <action>
+        <amount>-0.01</amount>
+        <action_type>refund</action_type>
+        <date>20200528211211</date>
+        <success>1</success>
+        <ip_address>97.71.146.67</ip_address>
+        <source>api</source>
+        <api_method></api_method>
+        <username>pftest</username>
+        <response_text></response_text>
+        <batch_id>0</batch_id>
+        <processor_batch_id></processor_batch_id>
+        <response_code>0</response_code>
+        <processor_response_text></processor_response_text>
+        <processor_response_code></processor_response_code>
+        <device_license_number></device_license_number>
+        <device_nickname></device_nickname>
+      </action>
+    </transaction>
+  </nm_response>
+  """
+}

--- a/fattmerchant_ios_sdkTests/Cardpresent/ChipDna/ChipDnaXMLTransactionParserTests.swift
+++ b/fattmerchant_ios_sdkTests/Cardpresent/ChipDna/ChipDnaXMLTransactionParserTests.swift
@@ -1,0 +1,41 @@
+//
+//  ChipDnaXMLTransactionParserTests.swift
+//  FattmerchantTests
+//
+//  Created by Tulio Troncoso on 6/1/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+class ChipDnaXMLTransactionParserTests: XCTestCase {
+
+  func testCanParseCcExpirationDateFromTransaction() {
+    let expectation = XCTestExpectation(description: "Parsed cc expiration date")
+    let xmlData = ChipDnaTransactionXmlResponse.xml.data(using: .utf8)!
+    let transactionId = ChipDnaTransactionXmlResponse.transactionId
+    let expectedCcExpiration = ChipDnaTransactionXmlResponse.ccExpiration
+    let parser = ChipDnaXMLTransactionParser()
+
+    parser.parseExpirationDate(from: xmlData, transactionId: transactionId) { ccExpiration in
+      XCTAssertEqual(ccExpiration, expectedCcExpiration)
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 3.0)
+  }
+
+  func testFailsIfEmptyTransactionIdGiven() {
+    let expectation = XCTestExpectation(description: "Nil ccExpiration returned")
+    let xmlData = ChipDnaTransactionXmlResponse.xml.data(using: .utf8)!
+    let parser = ChipDnaXMLTransactionParser()
+
+    parser.parseExpirationDate(from: xmlData, transactionId: "") { ccExpiration in
+      XCTAssertNil(ccExpiration)
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 3.0)
+  }
+}


### PR DESCRIPTION
## What is this
Transactions taken with an NMI mobile reader do not collect card expiration dates. This is because the ChipDNA SDK does not provide the card expiration dates after a transaction. 

## What did I do
Made NMI mobile reader transactions collect card expiration dates. This is accomplished by leveraging the NMI API to fetch the details of a transaction. 

![image](https://user-images.githubusercontent.com/5385681/83415086-8c51c580-a3ec-11ea-96d9-3054f2485132.png)


