### PR TITLE
[PHO-11] Show Mobile Reader Connection Status

### DIFF
--- a/Sample App/Fattmerchant-iOS-SDK-Sample/Base.lproj/Main.storyboard
+++ b/Sample App/Fattmerchant-iOS-SDK-Sample/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -25,7 +25,7 @@
                                 <rect key="frame" x="20" y="130" width="374" height="732"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="KoI-Tz-bhx">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="594"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="636"/>
                                         <subviews>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Su6-lv-kN3">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="300"/>
@@ -76,8 +76,15 @@
                                                     <action selector="onTakePaymentButtonPress:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Zvd-HY-rKY"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eOl-2C-891">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SdI-bW-DBU">
                                                 <rect key="frame" x="0.0" y="564" width="374" height="30"/>
+                                                <state key="normal" title="Cancel transaction"/>
+                                                <connections>
+                                                    <action selector="onCancelTransactionButtonPress:" destination="BYZ-38-t0r" eventType="touchUpInside" id="R6b-SB-YAh"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eOl-2C-891">
+                                                <rect key="frame" x="0.0" y="606" width="374" height="30"/>
                                                 <state key="normal" title="Take Payment with Card"/>
                                                 <connections>
                                                     <action selector="payWithCard" destination="BYZ-38-t0r" eventType="touchUpInside" id="O7V-Lw-anM"/>

--- a/Sample App/Fattmerchant-iOS-SDK-Sample/ViewController.swift
+++ b/Sample App/Fattmerchant-iOS-SDK-Sample/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Fattmerchant
 
-class ViewController: UIViewController, TransactionUpdateDelegate {
+class ViewController: UIViewController, TransactionUpdateDelegate, MobileReaderConnectionStatusDelegate {
 
   var omni: Omni?
 
@@ -41,7 +41,11 @@ class ViewController: UIViewController, TransactionUpdateDelegate {
     self.getReaderInfo()
   }
 
-  let apiKey = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJnb2RVc2VyIjpmYWxzZSwibWVyY2hhbnQiOiJlYjQ4ZWY5OS1hYTc4LTQ5NmUtOWIwMS00MjFmOGRhZjczMjMiLCJzdWIiOiJmMTI4YWQwNS0xYzhlLTQ3MmEtOWFlNi04MmE1MjdjMWFlNmMiLCJicmFuZCI6ImZhdHRtZXJjaGFudCIsImlzcyI6Imh0dHA6Ly9hcGlkZXYuZmF0dGxhYnMuY29tL2VwaGVtZXJhbCIsImlhdCI6MTU5MTU1NzQxMywiZXhwIjoxNTkxNjQzODEzLCJuYmYiOjE1OTE1NTc0MTMsImp0aSI6Ing5SGRZb3R1aXhwU25sOXMiLCJhc3N1bWluZyI6ZmFsc2V9.YhtfGsRgJ82PDLA3BBaxCsmTDLVJWs1TZz-Zn9kl1Ok"
+  @IBAction func onCancelTransactionButtonPress(_ sender: UIButton) {
+    self.cancelTransaction()
+  }
+
+  let apiKey = ""
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -58,6 +62,7 @@ class ViewController: UIViewController, TransactionUpdateDelegate {
     omni = Omni()
     omni?.signatureProvider = SignatureViewController()
     omni?.transactionUpdateDelegate = self
+    omni?.mobileReaderConnectionUpdateDelegate = self
 
     log("Attempting initalization...")
 
@@ -124,6 +129,14 @@ class ViewController: UIViewController, TransactionUpdateDelegate {
     })
   }
 
+  fileprivate func cancelTransaction() {
+    omni?.cancelMobileReaderTransaction(completion: { success in
+      self.log("Transaction cancelled")
+    }, error: { error in
+      self.log(error)
+    })
+  }
+
   fileprivate func getAmount() -> Amount {
     guard
       let text = totalTextInput.text ?? totalTextInput.placeholder,
@@ -185,6 +198,10 @@ class ViewController: UIViewController, TransactionUpdateDelegate {
     omni?.connect(reader: reader, completion: completion) {
       self.log("Couldn't connect to \(reader)")
     }
+  }
+
+  func mobileReaderConnectionStatusUpdate(status: MobileReaderConnectionStatus) {
+    self.log("Mobile reader \(status.rawValue)")
   }
 
   fileprivate func disconnectReader() {

--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		591C20A2206EB26700C848DA /* FattmerchantIosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C20A1206EB26700C848DA /* FattmerchantIosTests.swift */; };
 		594466AB249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594466AA249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift */; };
 		594466AC249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594466AA249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift */; };
+		594466AE249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594466AD249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift */; };
+		594466AF249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594466AD249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift */; };
+		594466B1249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594466B0249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift */; };
+		594466B2249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594466B0249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift */; };
 		59561818248C3FBD00E622B6 /* TransactionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59561817248C3FBD00E622B6 /* TransactionUpdate.swift */; };
 		597BEA48247FE205009319D6 /* TransactionUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA47247FE205009319D6 /* TransactionUpdateDelegate.swift */; };
 		597BEA4B2480C4C9009319D6 /* TransactionGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA4A2480C4C9009319D6 /* TransactionGateway.swift */; };
@@ -208,6 +212,8 @@
 		591C20A1206EB26700C848DA /* FattmerchantIosTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FattmerchantIosTests.swift; sourceTree = "<group>"; };
 		591C20A3206EB26700C848DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		594466AA249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelCurrentTransaction.swift; sourceTree = "<group>"; };
+		594466AD249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileReaderConnectionStatusDelegate.swift; sourceTree = "<group>"; };
+		594466B0249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileReaderConnectionStatus.swift; sourceTree = "<group>"; };
 		59561817248C3FBD00E622B6 /* TransactionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionUpdate.swift; sourceTree = "<group>"; };
 		597BEA47247FE205009319D6 /* TransactionUpdateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionUpdateDelegate.swift; sourceTree = "<group>"; };
 		597BEA4A2480C4C9009319D6 /* TransactionGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionGateway.swift; sourceTree = "<group>"; };
@@ -490,6 +496,7 @@
 				D79308C623D1045C0066FCA2 /* Omni.swift */,
 				D78FA931240EF48B00398D81 /* SignatureProviding.swift */,
 				597BEA47247FE205009319D6 /* TransactionUpdateDelegate.swift */,
+				594466AD249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift */,
 			);
 			path = Cardpresent;
 			sourceTree = "<group>";
@@ -583,6 +590,7 @@
 				D79308A923D0A9FB0066FCA2 /* TransactionRequest.swift */,
 				D79308AC23D0AA230066FCA2 /* TransactionResult.swift */,
 				59561817248C3FBD00E622B6 /* TransactionUpdate.swift */,
+				594466B0249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -857,6 +865,7 @@
 				D79308BE23D0AF3D0066FCA2 /* TakeMobileReaderPayment.swift in Sources */,
 				594466AB249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift in Sources */,
 				D79308A723D0A9050066FCA2 /* MobileReaderDriver.swift in Sources */,
+				594466B1249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift in Sources */,
 				D79308D023D22D900066FCA2 /* ChipDnaTransactionListener.swift in Sources */,
 				D765D49923CFC22600656040 /* PaymentMethodRepository.swift in Sources */,
 				D78FA932240EF48B00398D81 /* SignatureProviding.swift in Sources */,
@@ -890,6 +899,7 @@
 				D781037F23D9F85100256F2F /* PaginatedData.swift in Sources */,
 				D765D46623CC465800656040 /* Customer.swift in Sources */,
 				D7B7113B23D63B0D00EF98DB /* Environment.swift in Sources */,
+				594466AE249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift in Sources */,
 				5993C2662077B4EE004DDA9F /* BankHolderType.swift in Sources */,
 				D765D49C23CFC32200656040 /* TransactionRepository.swift in Sources */,
 				5993C2602076BD7D004DDA9F /* FattmerchantApi.swift in Sources */,
@@ -906,11 +916,13 @@
 				D760D82A23D884680075057C /* CustomerJson.swift in Sources */,
 				D765D4A023CFCA1400656040 /* Amount.swift in Sources */,
 				D783DAC42449F35E007C0A17 /* TakePaymentTests.swift in Sources */,
+				594466AF249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift in Sources */,
 				D7C17B2523E4BA200031D9BB /* SearchForReaders.swift in Sources */,
 				D73BBCF7244D805C0052B525 /* DisconnectMobileReaderTests.swift in Sources */,
 				D702B7CC23C8F80200B8AB79 /* PaymentMethod.swift in Sources */,
 				D7A28D622433E2CA00FC8872 /* TakePayment.swift in Sources */,
 				D7801C00241F355300A93001 /* OmniApi.swift in Sources */,
+				594466B2249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift in Sources */,
 				D765D47023CC488000656040 /* Merchant.swift in Sources */,
 				D765D47A23CC4B1100656040 /* CustomerRepository.swift in Sources */,
 				D7A28D652436278600FC8872 /* TokenizePaymentMethod.swift in Sources */,

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -71,6 +71,53 @@ extension TransactionUpdate {
   }
 }
 
+extension MobileReaderConnectionStatus {
+
+  /// Initializes a `MobileReaderConnectionStatus` object from the given ChipDnaConfigurationUpdate
+  ///
+  /// ChipDna hands us a ton of configuration updates during the mobile reader connection process. The ones we care
+  /// about are:
+  /// * Connecting
+  /// * Permorming Tms Update
+  /// * Updating Pinpad Firmware
+  /// * Rebooting
+  /// * Registering
+  ///
+  /// When any of these events are passed into this initializer, then the corresponding [MobileReaderConnectionStatus]
+  /// is created. When any other event is passed into this initializer, then the initialization fails and `nil` is
+  /// returned.
+  ///
+  /// - Note: Some [MobileReaderConnectionStatus] correspond to several ChipDna statuses. For example,
+  ///  `CCValueRegistering` and `CCValuePerformingTmsUpdate` both map to `MobileReaderConnectionStatus.updating`
+  ///
+  /// - Parameter chipDnaConfigurationUpdate: a string representation of the configuration update from ChipDna. This
+  /// is obtained by grabbing the value of `CCParamConfigurationUpdate`
+  init?(chipDnaConfigurationUpdate configUpdate: String) {
+    switch configUpdate {
+    case CCValueConnecting:
+      self = .connecting
+
+    case CCValueRegistering, CCValuePerformingTmsUpdate, CCValueUpdatingPinPadFirmware:
+      self = .updating
+
+    case CCValueRebootingPinPad:
+      self = .rebooting
+
+    default:
+      return nil
+    }
+  }
+
+  init?(chipDnaDeviceStatus: DeviceStatus) {
+    switch chipDnaDeviceStatus.deviceStatus {
+    case .disconnected:
+      self = .disconnected
+    default:
+      return nil
+    }
+  }
+}
+
 extension CCParameters {
 
   /// The param value to make NMI add a customer to the customer vault

--- a/fattmerchant-ios-sdk/Cardpresent/Data/MobileReaderConnectionStatus.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/MobileReaderConnectionStatus.swift
@@ -1,0 +1,29 @@
+//
+//  MobileReaderConnectionStatus.swift
+//  fattmerchant-ios-sdk
+//
+//  Created by Tulio Troncoso on 6/20/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+/// The status of a `MobileReader`
+public enum MobileReaderConnectionStatus: String {
+  /// The reader has been found by the iOS device and is currently being connected
+  case connecting
+
+  /// The reader is connected
+  case connected
+
+  /// The reader is disconnected
+  case disconnected
+
+  /// The reader is performing an update
+  ///
+  /// - Note: This might be a long-running operation
+  case updating
+
+  /// The reader is performing a reboot
+  case rebooting
+}

--- a/fattmerchant-ios-sdk/Cardpresent/MobileReaderConnectionStatusDelegate.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/MobileReaderConnectionStatusDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  MobileReaderConnectionStatusDelegate.swift
+//  fattmerchant-ios-sdk
+//
+//  Created by Tulio Troncoso on 6/20/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+/// Receives notifications of reader connection events such as when a reader is connecting or updating
+public protocol MobileReaderConnectionStatusDelegate: class {
+
+  /// Called when `MobileReader` has a new `MobileReaderConnectionStatus`
+  /// - Parameters:
+  ///   - status: The new `MobileReaderConnectionStatus` of the `reader`
+  func mobileReaderConnectionStatusUpdate(status: MobileReaderConnectionStatus)
+}

--- a/fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift
@@ -24,6 +24,8 @@ enum MobileReaderDriverException: OmniException {
 
 protocol MobileReaderDriver {
 
+  var mobileReaderConnectionStatusDelegate: MobileReaderConnectionStatusDelegate? { get set }
+
   func isReadyToTakePayment(completion: (Bool) -> Void)
 
   func initialize(args: [String: Any], completion: (Bool) -> Void)

--- a/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
@@ -10,6 +10,8 @@ import Foundation
 
 class MockDriver: MobileReaderDriver {
 
+  weak var mobileReaderConnectionStatusDelegate: MobileReaderConnectionStatusDelegate?
+
   var reader: MobileReader? = MobileReader(name: "Reader",
                             firmwareVersion: "FakeFirmwareVersion",
                             make: "FakeMake",

--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -87,7 +87,10 @@ public class Omni: NSObject {
   public var signatureProvider: SignatureProviding?
 
   /// Receives notifications about transaction events such as when a card is swiped
-  public var transactionUpdateDelegate: TransactionUpdateDelegate?
+  public weak var transactionUpdateDelegate: TransactionUpdateDelegate?
+
+  /// Receives notifications about reader connection events
+  public weak var mobileReaderConnectionUpdateDelegate: MobileReaderConnectionStatusDelegate?
 
   /// Contains all the data necessary to initialize `Omni`
   public struct InitParams {
@@ -292,7 +295,9 @@ public class Omni: NSObject {
       return error()
     }
 
-    let task = ConnectMobileReader(mobileReaderDriverRepository: mobileReaderDriverRepository, mobileReader: reader)
+    let task = ConnectMobileReader(mobileReaderDriverRepository: mobileReaderDriverRepository,
+                                   mobileReader: reader,
+                                   mobileReaderConnectionStatusDelegate: mobileReaderConnectionUpdateDelegate)
     task.start(onConnected: { connectedReader in
       completion(connectedReader)
     }, onFailed: { _ in
@@ -311,7 +316,9 @@ public class Omni: NSObject {
       return error(OmniGeneralException.uninitialized)
     }
 
-    let task = ConnectMobileReader(mobileReaderDriverRepository: mobileReaderDriverRepository, mobileReader: reader)
+    let task = ConnectMobileReader(mobileReaderDriverRepository: mobileReaderDriverRepository,
+                                   mobileReader: reader,
+                                   mobileReaderConnectionStatusDelegate: mobileReaderConnectionUpdateDelegate)
     task.start(onConnected: { connectedReader in
       self.preferredQueue.async {
         completion(connectedReader)

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/ConnectMobileReader.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/ConnectMobileReader.swift
@@ -18,17 +18,22 @@ class ConnectMobileReader {
 
   var mobileReaderDriverRepository: MobileReaderDriverRepository
   var mobileReader: MobileReader
+  weak var mobileReaderConnectionStatusDelegate: MobileReaderConnectionStatusDelegate?
 
-  init(mobileReaderDriverRepository: MobileReaderDriverRepository, mobileReader: MobileReader) {
+  init(mobileReaderDriverRepository: MobileReaderDriverRepository,
+       mobileReader: MobileReader,
+       mobileReaderConnectionStatusDelegate: MobileReaderConnectionStatusDelegate? = nil) {
     self.mobileReaderDriverRepository = mobileReaderDriverRepository
     self.mobileReader = mobileReader
+    self.mobileReaderConnectionStatusDelegate = mobileReaderConnectionStatusDelegate
   }
 
   func start(onConnected: @escaping (MobileReader) -> Void, onFailed: @escaping(OmniException) -> Void) {
 
     // First, try to see if the MobileReaderDriverRepo knows which Driver this MobileReader belongs to
     mobileReaderDriverRepository.getDriverFor(mobileReader: mobileReader) { (driver) in
-      if let driver = driver {
+      if var driver = driver {
+        driver.mobileReaderConnectionStatusDelegate = self.mobileReaderConnectionStatusDelegate
         driver.connect(reader: self.mobileReader, completion: { connected in
           if connected {
             onConnected(self.mobileReader)
@@ -49,7 +54,7 @@ class ConnectMobileReader {
             if callbackExecuted {
               return
             }
-
+            driver.mobileReaderConnectionStatusDelegate = self.mobileReaderConnectionStatusDelegate
             driver.connect(reader: self.mobileReader) { connected in
               if connected {
                 onConnected(self.mobileReader)


### PR DESCRIPTION
## What is this
When connecting to a mobile reader, there is no idea of what is happening from the moment that you call `omni.connect(reader:completion:error:)` to the moment that you hit the completion or the error block. However, the mobile reader is typically doing a ton of work during this time. Work that includes:
- Actually connecting the BT reader
- Making sure the BT reader can be used on behalf of the merchant
- Maybe doing a firmware update
- Maybe doing a TMS update
- Maybe rebooting
- Etc.

Another big problem is not knowing when a mobile reader disconnects by itself. If a mobile reader dies or is idle for too long, then it might disconnect itself from the iOS device. But prior to this PR, there is no way to listen for the disconnect event to allow the user to reconnect the mobile reader. 

## What did I do
I created a [`MobileReaderConnectionStatus` enum](https://github.com/fattmerchantorg/Fattmerchant-iOS-SDK/commit/513c01a6a103385a9e1437f73145b670b4a43f2f#diff-0d5ffa628a411d0b23e6cbb88ff02f3bR12) that shows all the states that the mobile reader can be in, and I created a `MobileReaderConnectionStatusDelegate` that emits a `MobileReaderConnectionStatus` every time there something changes with the status of the reader.

## Screenshots
See the sample app below, emitting the `connecting` and `disconnected` events
![IMG_992BA08C94AF-1](https://user-images.githubusercontent.com/5385681/85254661-ced85200-b42e-11ea-846c-a42a76147e9d.jpeg)
