### PR TITLE
[SPRINT-137][KRK-243] Add new confirm amount transaction update

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -65,6 +65,9 @@ extension TransactionUpdate {
     case TransactionUpdateOnlineAuthorisation:
       self = .Authorizing
 
+    case TransactionUpdateAmountConfirmationStarted:
+      self = .PromptConfirmAmountOnReader
+
     default:
       return nil
     }

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionUpdate.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionUpdate.swift
@@ -59,4 +59,8 @@ public struct TransactionUpdate {
   /// Signature provided
   public static let SignatureProvided = TransactionUpdate("Signature Provided")
 
+  /// Prompt user to confirm transaction amount on reader
+  ///
+  /// This `TransactionUpdate` is only emitted when the mobile reader supports on-device amount confirmation, like the Miura M010
+  public static let PromptConfirmAmountOnReader = TransactionUpdate("Prompt Confirm Amount On Reader", "Please confirm amount on reader")
 }


### PR DESCRIPTION
[KRK-243 Add missing transaction update for amount confirmation](https://fattmerchant.atlassian.net/browse/KRK-243)

## What I did
• Added new PromptConfirmAmountOnReader Transaction Update. This will be used by readers that allow on-device amount confirmation.

