### PR TITLE
[PHO-190] Submit payment against existing invoice

### DIFF
--- a/Sample App/Fattmerchant-iOS-SDK-Sample/ViewController.swift
+++ b/Sample App/Fattmerchant-iOS-SDK-Sample/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: UIViewController, TransactionUpdateDelegate {
     self.getReaderInfo()
   }
 
-  let apiKey = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJnb2RVc2VyIjpmYWxzZSwibWVyY2hhbnQiOiJlYjQ4ZWY5OS1hYTc4LTQ5NmUtOWIwMS00MjFmOGRhZjczMjMiLCJzdWIiOiJmMTI4YWQwNS0xYzhlLTQ3MmEtOWFlNi04MmE1MjdjMWFlNmMiLCJicmFuZCI6ImZhdHRtZXJjaGFudCIsImlzcyI6Imh0dHA6Ly9hcGlkZXYuZmF0dGxhYnMuY29tL2VwaGVtZXJhbCIsImlhdCI6MTU5MTU1NzQxMywiZXhwIjoxNTkxNjQzODEzLCJuYmYiOjE1OTE1NTc0MTMsImp0aSI6Ing5SGRZb3R1aXhwU25sOXMiLCJhc3N1bWluZyI6ZmFsc2V9.YhtfGsRgJ82PDLA3BBaxCsmTDLVJWs1TZz-Zn9kl1Ok"
+  let apiKey = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJtZXJjaGFudCI6ImViNDhlZjk5LWFhNzgtNDk2ZS05YjAxLTQyMWY4ZGFmNzMyMyIsImdvZFVzZXIiOnRydWUsImJyYW5kIjoiZmF0dG1lcmNoYW50Iiwic3ViIjoiMzBjNmVlYjYtNjRiNi00N2Y2LWJjZjYtNzg3YTljNTg3OThiIiwiaXNzIjoiaHR0cDovL2FwaWRldjAxLmZhdHRsYWJzLmNvbS9hdXRoZW50aWNhdGUiLCJpYXQiOjE1OTI4MDI3OTgsImV4cCI6MTU5Mjg4OTE5OCwibmJmIjoxNTkyODAyNzk4LCJqdGkiOiJDb3JIOU9lTHU3UjF6Smg3In0.UwkYOII_djnFCSqY7DNLEmggHbRzbERjryBR4SWlCAs"
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -147,7 +147,8 @@ class ViewController: UIViewController, TransactionUpdateDelegate {
   }
 
   fileprivate func createTransactionRequest() -> TransactionRequest {
-    let request = TransactionRequest(amount: getAmount())
+    var request = TransactionRequest(amount: getAmount())
+    request.invoiceId = "2bbe0ec0-f2d5-4fff-b6b3-0db8550cea77"
     return request
   }
 

--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		591C20A2206EB26700C848DA /* FattmerchantIosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C20A1206EB26700C848DA /* FattmerchantIosTests.swift */; };
 		594466AB249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594466AA249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift */; };
 		594466AC249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594466AA249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift */; };
+		594466B324A09D4C00C6CFD8 /* TransactionUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA47247FE205009319D6 /* TransactionUpdateDelegate.swift */; };
+		594466B424A09E4200C6CFD8 /* TransactionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59561817248C3FBD00E622B6 /* TransactionUpdate.swift */; };
 		59561818248C3FBD00E622B6 /* TransactionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59561817248C3FBD00E622B6 /* TransactionUpdate.swift */; };
 		597BEA48247FE205009319D6 /* TransactionUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA47247FE205009319D6 /* TransactionUpdateDelegate.swift */; };
 		597BEA4B2480C4C9009319D6 /* TransactionGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA4A2480C4C9009319D6 /* TransactionGateway.swift */; };
@@ -916,6 +918,7 @@
 				D7A28D652436278600FC8872 /* TokenizePaymentMethod.swift in Sources */,
 				D765D47623CC4A1400656040 /* Transaction.swift in Sources */,
 				D79308A823D0A9050066FCA2 /* MobileReaderDriver.swift in Sources */,
+				594466B324A09D4C00C6CFD8 /* TransactionUpdateDelegate.swift in Sources */,
 				D7C17B2423E4BA200031D9BB /* TakeMobileReaderPayment.swift in Sources */,
 				D79308AE23D0AA230066FCA2 /* TransactionResult.swift in Sources */,
 				D765D49723CFC1A000656040 /* InvoiceRepository.swift in Sources */,
@@ -929,6 +932,7 @@
 				D78FA933240EF48B00398D81 /* SignatureProviding.swift in Sources */,
 				D7801BF2241F264400A93001 /* MockModelRepository.swift in Sources */,
 				D783DAC12449E905007C0A17 /* ChargeRequest.swift in Sources */,
+				594466B424A09E4200C6CFD8 /* TransactionUpdate.swift in Sources */,
 				597BEA5124851B7D009319D6 /* ChipDnaXMLTransactionParserTests.swift in Sources */,
 				59F1FF3F24742F3F00019E06 /* TakeMobileReaderPaymentTests.swift in Sources */,
 				D7C17B2D23EA010F0031D9BB /* MockDriver.swift in Sources */,

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift
@@ -31,6 +31,9 @@ import Foundation
 /// let card = CreditCard(personName: "Joan Parsnip", cardNumber: "4111111111111111", cardExp: "1230", addressZip: "32822")
 /// let request = TransactionRequest(amount: amount, card: card)
 /// ```
+/// ## Paying a specific invoice
+/// If you want to associate the transaction with a specific invoice, include the id of the invoice in the
+/// `invoiceId` field
 public struct TransactionRequest {
 
   /// The `Amount` to be collected during the transaction
@@ -45,6 +48,11 @@ public struct TransactionRequest {
   ///
   /// Set this to false if you do not want the payment method stored
   public var tokenize: Bool = true
+
+  /// The id of the invoice that this payment should be applied to
+  ///
+  /// If nil, then a new invoice will be created
+  public var invoiceId: String?
 
   /// Initializes a TransactionRequest with the given amount.
   ///
@@ -81,5 +89,17 @@ public struct TransactionRequest {
     self.amount = amount
     self.tokenize = tokenize
     self.card = card
+  }
+
+  /// Initializes a TransactionRequest with the given amount and explicitly sets the tokenize value
+  /// - Parameters:
+  ///   - amount: The `Amount` to be collected during the transaction
+  ///   - tokenize: A value that dictates whether or not the payment method used in the transaction
+  ///   should be tokenized. Defaults to `true`
+  ///   - invoiceId: The invoice to associate this payment with. If nil, a new invoice is created. Defaults to nil.
+  public init(amount: Amount, tokenize: Bool = true, invoiceId: String? = nil) {
+    self.amount = amount
+    self.tokenize = tokenize
+    self.invoiceId = invoiceId
   }
 }

--- a/fattmerchant_ios_sdkTests/Mock/MockOmniApi.swift
+++ b/fattmerchant_ios_sdkTests/Mock/MockOmniApi.swift
@@ -25,10 +25,24 @@ class MockOmniApi: OmniApi {
     let completionResponse: Response
   }
 
+  /// This block runs before the mock omni api has executed one of the completion blocks, and is a good opportunity
+  /// to, for example, verify that the method has been called at all.
+  ///
+  /// All the arguments of the request are passed in here, so you can verify that a request is being attempted and
+  /// with which params
+  ///
+  /// Return true in the block if you want the request to proceed, false otherwise.
+  typealias Spy = (_ method: String, _ urlString: String, _ body: Data?) -> Bool
+
   fileprivate var stubs: [Stub] = []
+  fileprivate var spies: [Spy] = []
 
   func stub(_ method: String, _ url: String, body: Data?, response: Stub.Response) {
     stubs.append(Stub(method: method, url: url, body: body, completionResponse: response))
+  }
+
+  func spy(_ spy: @escaping Spy) {
+    spies.append(spy)
   }
 
   override func getSelf(completion: @escaping (OmniSelf) -> Void, failure: @escaping (OmniException) -> Void ) {
@@ -40,6 +54,14 @@ class MockOmniApi: OmniApi {
   }
 
   override func request<T>(method: String, urlString: String, body: Data? = nil, completion: @escaping (T) -> Void, failure: @escaping (OmniException) -> Void) where T : Decodable, T : Encodable {
+
+    // See if any of the spies want to prevent further execution
+    for spy in spies {
+      if spy(method, urlString, body) == true {
+        return
+      }
+    }
+
     if let stub = stubs.first(where: {
       $0.method == method
         && $0.url == urlString


### PR DESCRIPTION
https://fattmerchant.atlassian.net/browse/PHO-190

## What is this?
Users need to be able to associate their payment with an invoice that already exists

## What did I do?
- Added an `invoiceId` to the [`TransactionRequest` struct](https://github.com/fattmerchantorg/Fattmerchant-iOS-SDK/commit/025d5408db23830effa4a9e52290937db356b7b0#diff-d025cbab10121333cd2670457e5a9002R55). 

- Modified the TakeMobileReaderPayment usecase to respect the invoiceid, if provided
- Wrote tests