### PR TITLE
[MOB-38] Throw exception if transaction not cancelled

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
@@ -177,7 +177,7 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
 
   func cancelCurrentTransaction(completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void) {
     guard let transaction = currentTransaction else {
-      return completion(true)
+      return error(CancelCurrentTransactionException.noTransactionToCancel)
     }
     transaction.cancel()
     completion(transaction.isCancelled())

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -252,7 +252,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
       if let success = result[CCParamResult], success == CCValueTrue {
         completion(true)
       } else {
-        completion(false)
+        error(CancelCurrentTransactionException.unknown)
       }
     } else {
       fatalError()


### PR DESCRIPTION
## What is this
When a transaction cancellation is attempted but is unsuccessful, the `Omni#cancelTransaction` function still ends up calling the success block instead of the error one. 

## What did I do
Made `Omni#cancelTransaction` invoke the error block when a transaction wasn't cancelled