### PR TITLE
[SPRINT-143] [MOB-60] Get mobile reader settings from new route in gateway

### DIFF
--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		46C3ECC724CF551F005B4790 /* MobileReaderDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3ECC624CF551F005B4790 /* MobileReaderDetails.swift */; };
 		591C20A2206EB26700C848DA /* FattmerchantIosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C20A1206EB26700C848DA /* FattmerchantIosTests.swift */; };
 		593A7FAC24600FEF00D78874 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D793091123D256690066FCA2 /* CoreBluetooth.framework */; };
 		593A7FB02460118400D78874 /* AWCUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593A7FAF2460118400D78874 /* AWCUtils.swift */; };
@@ -216,6 +217,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		46C3ECC624CF551F005B4790 /* MobileReaderDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileReaderDetails.swift; sourceTree = "<group>"; };
 		591C2090206EB12F00C848DA /* Fattmerchant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Fattmerchant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		591C2094206EB12F00C848DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		591C209F206EB26600C848DA /* FattmerchantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FattmerchantTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -490,6 +492,7 @@
 				D765D47E23CCBBFD00656040 /* OmniException.swift */,
 				D79308A323D0A8B10066FCA2 /* MobileReader.swift */,
 				D783DABF2449E905007C0A17 /* ChargeRequest.swift */,
+				46C3ECC624CF551F005B4790 /* MobileReaderDetails.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -939,6 +942,7 @@
 				D765D47F23CCBBFD00656040 /* OmniException.swift in Sources */,
 				D79308C423D0E3C90066FCA2 /* RefundMobileReaderTransaction.swift in Sources */,
 				5993C25C2076BD68004DDA9F /* PaymentMethod.swift in Sources */,
+				46C3ECC724CF551F005B4790 /* MobileReaderDetails.swift in Sources */,
 				D79308AA23D0A9FB0066FCA2 /* TransactionRequest.swift in Sources */,
 				5993C2622076BD9B004DDA9F /* FattmerchantConfiguration.swift in Sources */,
 				D79308B823D0AC3A0066FCA2 /* ConnectMobileReader.swift in Sources */,

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
@@ -68,8 +68,8 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
         return
     }
     
-    let worldnetSecret = awcDetails.terminal_secret
-    let worldnetTerminalId = awcDetails.terminal_id
+    let worldnetSecret = awcDetails.terminalSecret
+    let worldnetTerminalId = awcDetails.terminalId
 
     // Initialize the AnyPay object. This will allow us to interact with AnyPay later on
     let anyPay = AnyPay.initialise()

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
@@ -62,13 +62,14 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
   ///   - completion: a block to run once initialization is complete. The block will receive the value 'true' if initialization was successful, false otherwise
   func initialize(args: [String: Any], completion: @escaping (Bool) -> Void) {
     guard
-      let awcDetails = args["awc"] as? AWCDetails,
-      let worldnetSecret = awcDetails.terminal_secret,
-      let worldnetTerminalId = awcDetails.terminal_id
+      let awcDetails = args["awc"] as? AWCDetails
       else {
         completion(false)
         return
     }
+    
+    let worldnetSecret = awcDetails.terminal_secret
+    let worldnetTerminalId = awcDetails.terminal_id
 
     // Initialize the AnyPay object. This will allow us to interact with AnyPay later on
     let anyPay = AnyPay.initialise()

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
@@ -67,7 +67,6 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
         completion(false)
         return
     }
-    
     let worldnetSecret = awcDetails.terminalSecret
     let worldnetTerminalId = awcDetails.terminalId
 
@@ -349,7 +348,6 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
     guard let serial = peripheral.name, serial.contains("CHB") == true else { return }
     self.discoveredBluetoothDeviceSerialNumbers.insert(serial)
   }
-
 
 }
 

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
@@ -62,9 +62,9 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
   ///   - completion: a block to run once initialization is complete. The block will receive the value 'true' if initialization was successful, false otherwise
   func initialize(args: [String: Any], completion: @escaping (Bool) -> Void) {
     guard
-      let merchant = args["merchant"] as? Merchant,
-      let worldnetSecret = merchant.emvTerminalSecret(),
-      let worldnetTerminalId = merchant.emvTerminalId()
+      let awcDetails = args["awc"] as? AWCDetails,
+      let worldnetSecret = awcDetails.terminal_secret,
+      let worldnetTerminalId = awcDetails.terminal_id
       else {
         completion(false)
         return

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -65,7 +65,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
         return
     }
     
-    let apiKey = nmiDetails.security_key
+    let apiKey = nmiDetails.securityKey
 
     // Store the apiKey and the init args for later use
     securityKey = apiKey

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -58,8 +58,8 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
   func initialize(args: [String: Any], completion: (Bool) -> Void) {
     guard
       let appId = args["appId"] as? String,
-      let merchant = args["merchant"] as? Merchant,
-      let apiKey = merchant.emvPassword(),
+      let nmiDetails = args["nmi"] as? NMIDetails,
+      let apiKey = nmiDetails.security_key,
       !apiKey.isEmpty
       else {
         completion(false)

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -59,12 +59,13 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
     guard
       let appId = args["appId"] as? String,
       let nmiDetails = args["nmi"] as? NMIDetails,
-      let apiKey = nmiDetails.security_key,
       !apiKey.isEmpty
       else {
         completion(false)
         return
     }
+    
+    let apiKey = nmiDetails.security_key
 
     // Store the apiKey and the init args for later use
     securityKey = apiKey

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -58,13 +58,11 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
   func initialize(args: [String: Any], completion: (Bool) -> Void) {
     guard
       let appId = args["appId"] as? String,
-      let nmiDetails = args["nmi"] as? NMIDetails,
-      !apiKey.isEmpty
+      let nmiDetails = args["nmi"] as? NMIDetails
       else {
         completion(false)
         return
     }
-    
     let apiKey = nmiDetails.securityKey
 
     // Store the apiKey and the init args for later use

--- a/fattmerchant-ios-sdk/Cardpresent/Networking/Endpoints.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Networking/Endpoints.swift
@@ -41,3 +41,9 @@ extension PaymentMethod: OmniEndpoint {
     return "/payment-method"
   }
 }
+
+extension MobileReaderDetails: OmniEndpoint {
+    static func resourceEndpoint() -> String {
+        return "/team/gateway/hardware/mobile"
+    }
+}

--- a/fattmerchant-ios-sdk/Cardpresent/Networking/OmniApi.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Networking/OmniApi.swift
@@ -55,7 +55,6 @@ class OmniApi {
   func getSelf(completion: @escaping (OmniSelf) -> Void, failure: @escaping (OmniException) -> Void ) {
     request(method: "get", urlString: "/self", completion: completion, failure: failure)
   }
-    
   func getMobileReaderSettings(completion: @escaping (MobileReaderDetails) -> Void, failure: @escaping (OmniException) -> Void) {
     request(method: "get", urlString: MobileReaderDetails.resourceEndpoint(), completion: completion, failure: failure)
   }
@@ -70,7 +69,7 @@ class OmniApi {
                         total: String? = nil,
                         completion: @escaping (Transaction) -> Void,
                         error: @escaping (OmniException) -> Void) {
-    var body: Data? = nil
+    var body: Data?
     if let total = total {
       body = try? jsonEncoder().encode(["total": total])
     }

--- a/fattmerchant-ios-sdk/Cardpresent/Networking/OmniApi.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Networking/OmniApi.swift
@@ -55,6 +55,10 @@ class OmniApi {
   func getSelf(completion: @escaping (OmniSelf) -> Void, failure: @escaping (OmniException) -> Void ) {
     request(method: "get", urlString: "/self", completion: completion, failure: failure)
   }
+    
+  func getMobileReaderSettings(completion: @escaping (MobileReaderDetails) -> Void, failure: @escaping (OmniException) -> Void) {
+    request(method: "get", urlString: MobileReaderDetails.resourceEndpoint(), completion: completion, failure: failure)
+  }
 
   /// Posts a void-or-refund to Omni
   /// - Parameters:

--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -156,26 +156,20 @@ public class Omni: NSObject {
       // Assign merchant to self
       self.merchant = merchant
     }, failure: error)
-    
     omniApi.getMobileReaderSettings(completion: { mrDetails in
-        
         var args: [String: Any] = [
-          "appId": appId,
+          "appId": appId
         ]
-        
         if let awcDetails = mrDetails.anywhereCommerce {
             args.updateValue(awcDetails, forKey: "awc")
         }
-        
         if let nmiDetails = mrDetails.nmi {
             args.updateValue(nmiDetails, forKey: "nmi")
         }
-        
-        if(args["awc"] == nil && args["nmi"] == nil) {
+        if args["awc"] == nil && args["nmi"] == nil {
             error(OmniNetworkingException.couldNotGetMobileReaderDetails)
             return
         }
-        
         InitializeDrivers(mobileReaderDriverRepository: self.mobileReaderDriverRepository, args: args).start(completion: { _ in
           self.initialized = true
           self.preferredQueue.async(execute: completion)

--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum OmniNetworkingException: OmniException {
   case couldNotGetMerchantDetails
+  case couldNotGetMobileReaderDetails
   case couldNotGetPaginatedTransactions
 
   static var mess: String = "Omni Networking Exception"
@@ -21,6 +22,8 @@ enum OmniNetworkingException: OmniException {
 
     case .couldNotGetPaginatedTransactions:
       return "Could not get paginated transactions"
+    case .couldNotGetMobileReaderDetails:
+      return "Could not get mobile reader details from Omni"
     }
   }
 }
@@ -152,16 +155,31 @@ public class Omni: NSObject {
 
       // Assign merchant to self
       self.merchant = merchant
-
-      let args: [String: Any] = [
-        "appId": appId,
-        "merchant": merchant
-      ]
-
-      InitializeDrivers(mobileReaderDriverRepository: self.mobileReaderDriverRepository, args: args).start(completion: { _ in
-        self.initialized = true
-        self.preferredQueue.async(execute: completion)
-      }, failure: error)
+    }, failure: error)
+    
+    omniApi.getMobileReaderSettings(completion: { mrDetails in
+        
+        var args: [String: Any] = [
+          "appId": appId,
+        ]
+        
+        if let awcDetails = mrDetails.anywhere_commerce {
+            args.updateValue(awcDetails, forKey: "awc")
+        }
+        
+        if let nmiDetails = mrDetails.nmi {
+            args.updateValue(nmiDetails, forKey: "nmi")
+        }
+        
+        if(args["awc"] == nil && args["nmi"] == nil) {
+            error(OmniNetworkingException.couldNotGetMobileReaderDetails)
+            return
+        }
+        
+        InitializeDrivers(mobileReaderDriverRepository: self.mobileReaderDriverRepository, args: args).start(completion: { _ in
+          self.initialized = true
+          self.preferredQueue.async(execute: completion)
+        }, failure: error)
     }, failure: error)
 
   }

--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -163,7 +163,7 @@ public class Omni: NSObject {
           "appId": appId,
         ]
         
-        if let awcDetails = mrDetails.anywhere_commerce {
+        if let awcDetails = mrDetails.anywhereCommerce {
             args.updateValue(awcDetails, forKey: "awc")
         }
         

--- a/fattmerchant-ios-sdk/Models/MobileReaderDetails.swift
+++ b/fattmerchant-ios-sdk/Models/MobileReaderDetails.swift
@@ -11,13 +11,10 @@ import Foundation
 /// Mobile reader settings defined in the mobile reader tab
 class MobileReaderDetails: Model, Codable {
     public var id: String?
-    
     /// Holds details for AnywhereCommerce settings set in the mobile reader tab
     internal var anywhereCommerce: AWCDetails?
-    
     /// Holds details for NMI settings set in the mobile reader tab
     internal var nmi: NMIDetails?
-    
 }
 
 /// Details for AnywhereCommerce settings set in the mobile reader tab

--- a/fattmerchant-ios-sdk/Models/MobileReaderDetails.swift
+++ b/fattmerchant-ios-sdk/Models/MobileReaderDetails.swift
@@ -1,0 +1,35 @@
+//
+//  MobileReaderSettings.swift
+//  Fattmerchant
+//
+//  Created by Hassan Nazari on 7/27/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+/// Mobile reader settings defined in the mobile reader tab
+class MobileReaderDetails: Model, Codable {
+    public var id: String?
+    
+    /// Holds details for AnywhereCommerce settings set in the mobile reader tab
+    internal var anywhere_commerce: AWCDetails?
+    
+    /// Holds details for NMI settings set in the mobile reader tab
+    internal var nmi: NMIDetails?
+    
+}
+
+/// Details for AnywhereCommerce settings set in the mobile reader tab
+internal struct AWCDetails: Codable {
+    /// AnywhereCommerce terminal id
+    var terminal_id: String
+    /// AnywhereCommerce secret
+    var terminal_secret: String
+}
+
+/// Details for NMI (ChipDNA) settings set in the mobile reader tab
+internal struct NMIDetails: Codable {
+    /// NMI (ChipDNA) security key
+    var security_key: String
+}

--- a/fattmerchant-ios-sdk/Models/MobileReaderDetails.swift
+++ b/fattmerchant-ios-sdk/Models/MobileReaderDetails.swift
@@ -13,7 +13,7 @@ class MobileReaderDetails: Model, Codable {
     public var id: String?
     
     /// Holds details for AnywhereCommerce settings set in the mobile reader tab
-    internal var anywhere_commerce: AWCDetails?
+    internal var anywhereCommerce: AWCDetails?
     
     /// Holds details for NMI settings set in the mobile reader tab
     internal var nmi: NMIDetails?
@@ -23,13 +23,13 @@ class MobileReaderDetails: Model, Codable {
 /// Details for AnywhereCommerce settings set in the mobile reader tab
 internal struct AWCDetails: Codable {
     /// AnywhereCommerce terminal id
-    var terminal_id: String
+    var terminalId: String
     /// AnywhereCommerce secret
-    var terminal_secret: String
+    var terminalSecret: String
 }
 
 /// Details for NMI (ChipDNA) settings set in the mobile reader tab
 internal struct NMIDetails: Codable {
     /// NMI (ChipDNA) security key
-    var security_key: String
+    var securityKey: String
 }


### PR DESCRIPTION
## What is this
We are now getting the mobile reader settings from a new route: `team/gateway/hardware/mobile` instead of passing along that data from the merchant object.
## What did I do
Instead of passing the merchant object along to the drivers, I pass the retrieved mobile reader details. This is the same for both NMI and AWC readers.