### PR TITLE
[SPRINT-144][MOB-68] Support catalog items

### DIFF
--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		46231C5B24DAF4A500A06E1B /* CatalogItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46231C5A24DAF4A500A06E1B /* CatalogItem.swift */; };
+		46231C5C24DAF4A500A06E1B /* CatalogItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46231C5A24DAF4A500A06E1B /* CatalogItem.swift */; };
+		46231C5D24DAFF8100A06E1B /* MobileReaderDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3ECC624CF551F005B4790 /* MobileReaderDetails.swift */; };
 		46C3ECC724CF551F005B4790 /* MobileReaderDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C3ECC624CF551F005B4790 /* MobileReaderDetails.swift */; };
 		591C20A2206EB26700C848DA /* FattmerchantIosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C20A1206EB26700C848DA /* FattmerchantIosTests.swift */; };
 		593A7FAC24600FEF00D78874 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D793091123D256690066FCA2 /* CoreBluetooth.framework */; };
@@ -217,6 +220,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		46231C5A24DAF4A500A06E1B /* CatalogItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatalogItem.swift; sourceTree = "<group>"; };
 		46C3ECC624CF551F005B4790 /* MobileReaderDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileReaderDetails.swift; sourceTree = "<group>"; };
 		591C2090206EB12F00C848DA /* Fattmerchant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Fattmerchant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		591C2094206EB12F00C848DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -493,6 +497,7 @@
 				D79308A323D0A8B10066FCA2 /* MobileReader.swift */,
 				D783DABF2449E905007C0A17 /* ChargeRequest.swift */,
 				46C3ECC624CF551F005B4790 /* MobileReaderDetails.swift */,
+				46231C5A24DAF4A500A06E1B /* CatalogItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -907,6 +912,7 @@
 				D79308AD23D0AA230066FCA2 /* TransactionResult.swift in Sources */,
 				D79308A423D0A8B10066FCA2 /* MobileReader.swift in Sources */,
 				593A7FD7246878B700D78874 /* AsyncFilter.swift in Sources */,
+				46231C5B24DAF4A500A06E1B /* CatalogItem.swift in Sources */,
 				D765D47523CC4A1400656040 /* Transaction.swift in Sources */,
 				D7A28D612433E2CA00FC8872 /* TakePayment.swift in Sources */,
 				D79308C723D1045C0066FCA2 /* Omni.swift in Sources */,
@@ -986,6 +992,7 @@
 				D765D49723CFC1A000656040 /* InvoiceRepository.swift in Sources */,
 				D73BBCF3244D697F0052B525 /* GetConnectedMobileReader.swift in Sources */,
 				D702B7CD23C8F80200B8AB79 /* CreditCard.swift in Sources */,
+				46231C5D24DAFF8100A06E1B /* MobileReaderDetails.swift in Sources */,
 				D7692F1923E4B00500CB0954 /* OmniTest.swift in Sources */,
 				D781038023D9F85100256F2F /* PaginatedData.swift in Sources */,
 				D79308D523D24C880066FCA2 /* Endpoints.swift in Sources */,
@@ -1034,6 +1041,7 @@
 				597BEA5324851BA9009319D6 /* ChipDnaTransctionXMLResponse.swift in Sources */,
 				D7D2C51E23F203F8001733A2 /* RefundMobileReaderTransactionTests.swift in Sources */,
 				D79308A023D0A1B50066FCA2 /* AmountTests.swift in Sources */,
+				46231C5C24DAF4A500A06E1B /* CatalogItem.swift in Sources */,
 				D7692F1A23E4B03200CB0954 /* Omni.swift in Sources */,
 				D765D49D23CFC32200656040 /* TransactionRepository.swift in Sources */,
 				D760D82823D87F5D0075057C /* InvoiceJson.swift in Sources */,

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift
@@ -38,29 +38,26 @@ public struct TransactionRequest {
 
   /// The `Amount` to be collected during the transaction
   public var amount: Amount
-
   /// The `CreditCard` to charge
   public var card: CreditCard?
-
+  /// The `LineItem`s being passed to the transaction
+  public var lineItems: [CatalogItem]?
   /// The option to tokenize the payment method for later usage
   ///
   /// - Note: Defaults to true
   ///
   /// Set this to false if you do not want the payment method stored
   public var tokenize: Bool = true
-
   /// The id of the invoice that this payment should be applied to
   ///
   /// If nil, then a new invoice will be created
   public var invoiceId: String?
-
   /// Initializes a TransactionRequest with the given amount.
   ///
   /// - Parameter amount: The  `Amount` to be collected during the transaction
   public init(amount: Amount) {
     self.amount = amount
   }
-
   /// Initializes a TransactionRequest with the given amount.
   ///
   /// - Parameter amount: The  `Amount` to be collected during the transaction
@@ -68,7 +65,6 @@ public struct TransactionRequest {
     self.amount = amount
     self.card = card
   }
-
   /// Initializes a TransactionRequest with the given amount and explicitly sets the tokenize value
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction
@@ -78,7 +74,6 @@ public struct TransactionRequest {
     self.amount = amount
     self.tokenize = tokenize
   }
-
   /// Initializes a TransactionRequest with the given amount and explicitly sets the tokenize value
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction
@@ -90,7 +85,6 @@ public struct TransactionRequest {
     self.tokenize = tokenize
     self.card = card
   }
-
   /// Initializes a TransactionRequest with the given amount and explicitly sets the tokenize value
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction
@@ -101,5 +95,36 @@ public struct TransactionRequest {
     self.amount = amount
     self.tokenize = tokenize
     self.invoiceId = invoiceId
+  }
+  /// Initializes a TransactionRequest with the given amount and a list of line items
+  /// - Parameters:
+  ///   - amount: The `Amount` to be collected during the transaction
+  ///   - lineItems: A list of  `LineItem` that are attached to the transaction
+  public init(amount: Amount, lineItems: [CatalogItem]) {
+    self.amount = amount
+    self.lineItems = lineItems
+  }
+  /// Initializes a TransactionRequest with the given amount and a list of line items
+  /// - Parameters:
+  ///   - amount: The `Amount` to be collected during the transaction
+  ///   - card: A `CreditCard` to charge
+  ///   - lineItems: A list of  `LineItem` that are attached to the transaction
+  public init(amount: Amount, card: CreditCard, lineItems: [CatalogItem]) {
+    self.amount = amount
+    self.card = card
+    self.lineItems = lineItems
+  }
+  /// Initializes a TransactionRequest with the given amount, explicitly sets the tokenize value and a contains a list of line items
+  /// - Parameters:
+  ///   - amount: The `Amount` to be collected during the transaction
+  ///   - tokenize: A value that dictates whether or not the payment method used in the transaction
+  ///   should be tokenized.
+  ///   - card: A `CreditCard` to charge
+  ///   - lineItems: A list of  `LineItem` that are attached to the transaction
+  public init(amount: Amount, tokenize: Bool, card: CreditCard, lineItems: [CatalogItem]) {
+    self.amount = amount
+    self.tokenize = tokenize
+    self.card = card
+    self.lineItems = lineItems
   }
 }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -203,6 +203,14 @@ class TakeMobileReaderPayment {
     if let gatewayResponse = transactionResult.gatewayResponse {
       dict["gatewayResponse"] = gatewayResponse
     }
+    let encoder = JSONEncoder()
+    if let lineItemResponse = transactionResult.request?.lineItems {
+      do {
+        dict["lineItems"] = String(data: try encoder.encode(lineItemResponse), encoding: .utf8)
+      } catch {
+        /// If this fails we don't care
+      }
+    }
 
     return dict.jsonValue()
   }

--- a/fattmerchant-ios-sdk/Models/CatalogItem.swift
+++ b/fattmerchant-ios-sdk/Models/CatalogItem.swift
@@ -1,0 +1,22 @@
+//
+//  CatalogItem.swift
+//  fattmerchant-ios-sdk
+//
+//  Created by Hassan Nazari on 8/4/20.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+public struct CatalogItem: Model, Codable {
+    /// The omni id of the item
+    public var id: String?
+    /// The name of the item
+    public var item: String
+    /// The description of the item
+    public var details: String
+    ///. The number of items to be purchased
+    public var quantity: Int
+    /// The price of the item in dollars
+    public var price: Double
+}


### PR DESCRIPTION
## What is this
This adds support in the SDK for the ability to provide a list of catalog items to a transaction request. It uses the `meta` field in the `TransactionRequest` to pass to the Omni API.

## What did I do
Added a new model object called `CatalogItem` which maps the object passed to the `meta` field.
Added `lineItems` array to the `TransactionRequest` and created a few public initializers to support the new field.
Added a new dictionary item to the meta data being passed in the use case of `TakeMobileReaderPayment` that contains the encoded line items.
Wrote a test case for taking a mobile reader transaction with catalog items.