### PR TITLE
[MOB-93] Improvements to initialize error messages

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -58,7 +58,8 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
   func initialize(args: [String: Any], completion: (Bool) -> Void) {
     guard
       let appId = args["appId"] as? String,
-      let nmiDetails = args["nmi"] as? NMIDetails
+      let nmiDetails = args["nmi"] as? NMIDetails,
+      !nmiDetails.securityKey.isEmpty
       else {
         completion(false)
         return
@@ -74,6 +75,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
     parameters.setValue("password", forKey: CCParamPassword)
     parameters.setValue(CCValueTrue, forKey: CCParamAutoConfirm)
     if ChipDnaMobile.initialize(parameters)?[CCParamResult] != CCValueTrue {
+      ChipDnaMobile.dispose(nil)
       completion(false)
       return
     }
@@ -85,6 +87,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
     properties.setValue(CCValueEnvironmentLive, forKey: CCParamEnvironment)
     let setPropertiesResult = ChipDnaMobile.sharedInstance()?.setProperties(properties)
     if setPropertiesResult?[CCParamResult] != CCValueTrue {
+      ChipDnaMobile.dispose(nil)
       completion(false)
       return
     }

--- a/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
@@ -30,12 +30,18 @@ class MockDriver: MobileReaderDriver {
 
   static var omniRefundsSupported: Bool = false
 
-  func isReadyToTakePayment(completion: (Bool) -> Void) {
-    completion(readyToTakePayment)
+  func isReadyToTakePayment(completion: (Bool, OmniException?) -> Void) {
+    completion(readyToTakePayment, nil)
   }
 
   func initialize(args: [String: Any], completion: (Bool) -> Void) {
-    completion(true)
+    if let nmiArgs = args["nmi"] as? NMIDetails {
+      return completion(!nmiArgs.securityKey.isEmpty)
+    } else if let awcArgs = args["awc"] as? AWCDetails {
+      return completion(!awcArgs.terminalId.isEmpty && !awcArgs.terminalSecret.isEmpty)
+    } else {
+      return completion(false)
+    }
   }
 
   func isInitialized(completion: @escaping (Bool) -> Void) {

--- a/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
@@ -30,8 +30,8 @@ class MockDriver: MobileReaderDriver {
 
   static var omniRefundsSupported: Bool = false
 
-  func isReadyToTakePayment(completion: (Bool, OmniException?) -> Void) {
-    completion(readyToTakePayment, nil)
+  func isReadyToTakePayment(completion: (Bool) -> Void) {
+    completion(readyToTakePayment)
   }
 
   func initialize(args: [String: Any], completion: (Bool) -> Void) {

--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -10,7 +10,6 @@ import Foundation
 
 enum OmniNetworkingException: OmniException {
   case couldNotGetMerchantDetails
-  case couldNotGetMobileReaderDetails
   case couldNotGetPaginatedTransactions
 
   static var mess: String = "Omni Networking Exception"
@@ -22,14 +21,13 @@ enum OmniNetworkingException: OmniException {
 
     case .couldNotGetPaginatedTransactions:
       return "Could not get paginated transactions"
-    case .couldNotGetMobileReaderDetails:
-      return "Could not get mobile reader details from Omni"
     }
   }
 }
 
 enum OmniInitializeException: OmniException {
   case missingInitializationDetails
+  case mobileReaderPaymentsNotConfigured
 
   static var mess: String = "Omni Initialization Exception"
 
@@ -37,6 +35,9 @@ enum OmniInitializeException: OmniException {
     switch self {
     case .missingInitializationDetails:
       return "Missing initialization details"
+
+    case .mobileReaderPaymentsNotConfigured:
+      return "Your account is not configured to accept mobile reader payments"
     }
   }
 }
@@ -182,7 +183,7 @@ public class Omni: NSObject {
             args.updateValue(nmiDetails, forKey: "nmi")
         }
         if args["awc"] == nil && args["nmi"] == nil {
-            error(OmniNetworkingException.couldNotGetMobileReaderDetails)
+            error(OmniInitializeException.mobileReaderPaymentsNotConfigured)
             return
         }
         InitializeDrivers(mobileReaderDriverRepository: self.mobileReaderDriverRepository, args: args).start(completion: { _ in

--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -25,13 +25,13 @@ enum OmniNetworkingException: OmniException {
   }
 }
 
-enum OmniInitializeException: OmniException {
+public enum OmniInitializeException: OmniException {
   case missingInitializationDetails
   case mobileReaderPaymentsNotConfigured
 
-  static var mess: String = "Omni Initialization Exception"
+  public static var mess: String = "Omni Initialization Exception"
 
-  var detail: String? {
+  public var detail: String? {
     switch self {
     case .missingInitializationDetails:
       return "Missing initialization details"
@@ -42,12 +42,12 @@ enum OmniInitializeException: OmniException {
   }
 }
 
-enum OmniGeneralException: OmniException {
+public enum OmniGeneralException: OmniException {
   case uninitialized
 
-  static var mess: String = "Omni General Error"
+  public static var mess: String = "Omni General Error"
 
-  var detail: String? {
+  public var detail: String? {
     switch self {
     case .uninitialized:
       return "Omni has not been initialized yet"

--- a/fattmerchant-ios-sdk/Models/OmniException.swift
+++ b/fattmerchant-ios-sdk/Models/OmniException.swift
@@ -16,7 +16,7 @@ public protocol OmniException: Error {
 }
 
 extension OmniException {
-  var message: String {
+  public var message: String {
     return Self.mess
   }
 

--- a/fattmerchant_ios_sdkTests/Cardpresent/RefundMobileReaderTransactionTests.swift
+++ b/fattmerchant_ios_sdkTests/Cardpresent/RefundMobileReaderTransactionTests.swift
@@ -66,7 +66,7 @@ XCTAssertNotNil(getRefundValidationError(total: 1.0, totalRefunded: 0.0, refundA
 
     let expectation = XCTestExpectation(description: "Request to omni is build properly")
     let expectedMethod = "post"
-    let expectedUrlString = "/transaction/\(transactionId)/void-or-refunds"
+    let expectedUrlString = "/transaction/\(transactionId)/void-or-refund"
     let expectedBody: Data? = nil
 
     // We want mock omni api to be called witha void-or-refund


### PR DESCRIPTION
https://fattmerchant.atlassian.net/browse/MOB-93

## What is this
There is an error that's commonly thrown, `InitializeDriversException.noMobileReadersFound`. A lack of mobile readers is often not the root cause of this error. We should be more explicit about what exactly is going on and avoid throwing this error unless the only thing wrong is really that there are no mobile readers found while doing a BT scan.

## What did i do
- Added a fallback to the process of getting reader settings. If the merchant gateways doesn't have the reader settings, then we can use the ones in merchant options. if there none in there, only then do we fail.
- Prevented initialization of ChipDna if the securityKey is blank. There was an issue where ChipDNA was getting initialized even with a blank key, so when we called `mobileReaderDriverRepo.initializedDrivers()`, ChiPDNA would be returned even though it really shouldn't be initialized.
- Added an exception for incorrectMobileReaderSettings. This gets thrown if the reader settings are provided, but they are wrong.
- Renamed `couldNotGetMobileReaderDetails` to `mobileReaderPaymentsNotConfigured`. This is a better prompt to the developer that they should reach out to FM for help, since nothing they do is going to help them move forward.