### PR TITLE
[SPRINT-146][MOB-102] Request chip cards be inserted for AWC transactions

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
@@ -16,46 +16,33 @@ import CoreBluetooth
 
 /// A `MobileReaderDriver` that controls AnywhereCommerce mobile readers
 class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
-
   /// Manages the search of BT devices
   fileprivate var btCentralManager: CBCentralManager?
-
   /// Holds a set of the bluetooth devices that have been discovered for the purpose of BT connection
   ///
   /// - Note: This set is cleared every time a new BT search is conducted
   fileprivate var discoveredBluetoothDeviceSerialNumbers: Set<String> = []
-
   /// A test endpoint for AWC
   fileprivate var testGatewayUrl = "https://testpayments.anywherecommerce.com/merchant"
-
   /// The live endpoint for AWC
   fileprivate var gatewayUrl = "https://payments.anywherecommerce.com/merchant"
-
   /// A test terminalId for AWC
   fileprivate var testTerminalId = "2994002"
-
   /// A test TerminalKey for AWC
   fileprivate var testTerminalKey = "password"
-
   /// Allows us to interact with AnywhereCommerce
   fileprivate var anyPay: AnyPay?
-
   /// The transaction currently underway
   fileprivate var currentTransaction: AnyPayTransaction?
-
   /// Listens to transaction update events
   weak var transactionUpdateDelegate: TransactionUpdateDelegate?
-
   /// Listens to mobile reader status update events
   weak var mobileReaderConnectionStatusDelegate: MobileReaderConnectionStatusDelegate?
-
   /// The place where the transactions take place
   static var source: String = "AWC"
-
   static var omniRefundsSupported: Bool = false
-
   var familiarSerialNumbers: [String] = []
-
+  var transactionUpdateDelay: Double = 0.0
   /// Attempts to initialize the AnyPay SDK
   /// - Parameters:
   ///   - args: a Dictionary containing all necessary data to initialize the sdk
@@ -69,11 +56,9 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
     }
     let worldnetSecret = awcDetails.terminalSecret
     let worldnetTerminalId = awcDetails.terminalId
-
     // Initialize the AnyPay object. This will allow us to interact with AnyPay later on
     let anyPay = AnyPay.initialise()
     self.anyPay = anyPay
-
     // Configure the endpoint object
     guard let endpoint = anyPay.terminal.endpoint as? ANPWorldnetEndpoint else {
       return
@@ -81,7 +66,6 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
     endpoint.worldnetTerminalID = worldnetTerminalId
     endpoint.worldnetSecret = worldnetSecret
     endpoint.gatewayUrl = gatewayUrl
-
     // Authenticate
     anyPay.terminal.endpoint.authenticateTerminal { (authenticated, _) in
       // If we were unable to authenticate with AWC, then clear out the anyPay instance
@@ -93,40 +77,32 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
           self.mobileReaderConnectionStatusDelegate?.mobileReaderConnectionStatusUpdate(status: .disconnected)
         }
       }
-
       completion(authenticated)
     }
   }
-
   func isInitialized(completion: @escaping (Bool) -> Void) {
     completion(anyPay != nil)
   }
-
   func isReadyToTakePayment(completion: (Bool) -> Void) {
     // Make sure the reader is connected
     guard let connectedReader = ANPCardReaderController.shared().connectedReader else {
       return completion(false)
     }
-
     // Make sure reader is idle
     guard connectedReader.connectionStatus == ANPCardReaderConnectionStatus.CONNECTED else {
       return completion(false)
     }
-
     // Make sure there is no transaction running
     guard currentTransaction == nil else {
       return completion(false)
     }
-
     completion(true)
   }
-
   func searchForReaders(args: [String: Any], completion: @escaping ([MobileReader]) -> Void) {
     // Start searching
     guard startBtDeviceSearch() else {
       return completion([])
     }
-
     // After some time, stop searching and report the results
     let deadline = DispatchTime.now() + DispatchTimeInterval.seconds(3)
     DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: deadline) {
@@ -137,20 +113,17 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
       completion(readers)
     }
   }
-
   func connect(reader: MobileReader, completion: @escaping (MobileReader?) -> Void) {
     // If the reader we want to connect is already connect it, just return it
     if let connectedReader = connectedReader(), connectedReader.serialNumber == reader.serialNumber {
       completion(connectedReader)
       return
     }
-
     // Can't connect to a reader without a serial number
     guard let serialNumber = reader.serialNumber else {
       completion(nil)
       return
     }
-
     // Subscribe to events
     onCardReaderConnected = { reader in
       if let reader = reader {
@@ -160,21 +133,17 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
         completion(nil)
       }
     }
-
     onCardReaderConnectionFailed = { _ in
       completion(nil)
     }
-
     // Request that AWC connect the reader
     mobileReaderConnectionStatusDelegate?.mobileReaderConnectionStatusUpdate(status: .connecting)
     ANPCardReaderController.shared().connectToBluetoothReader(withSerial: serialNumber)
   }
-
   func disconnect(reader: MobileReader, completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void) {
     ANPCardReaderController.shared().disconnectReader()
     completion(true)
   }
-
   func cancelCurrentTransaction(completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void) {
     guard let transaction = currentTransaction else {
       return error(CancelCurrentTransactionException.noTransactionToCancel)
@@ -182,7 +151,6 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
     transaction.cancel()
     completion(transaction.isCancelled())
   }
-
   func performTransaction(with request: TransactionRequest,
                           signatureProvider: SignatureProviding?,
                           transactionUpdateDelegate: TransactionUpdateDelegate?,
@@ -191,11 +159,9 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
     let transaction = AnyPayTransaction(type: .SALE)
     transaction?.currency = "USD"
     transaction?.totalAmount = ANPAmount(string: request.amount.dollarsString())
-
     // Register block for capturing signature
     transaction?.onSignatureRequired = {
       transactionUpdateDelegate?.onTransactionUpdate(transactionUpdate: .PromptProvideSignature)
-
       if let signatureProvider = signatureProvider {
         signatureProvider.signatureRequired(completion: { signature in
           transactionUpdateDelegate?.onTransactionUpdate(transactionUpdate: .SignatureProvided)
@@ -212,11 +178,10 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
         transaction?.proceed()
       }
     }
-
     currentTransaction = transaction
-    transaction?.execute({ (transactionStatus, error) in
+    transaction?.execute({ (_, _) in
       self.currentTransaction = nil
-      let result = TransactionResult(transaction!)
+       let result = TransactionResult(transaction!)
       completion(result)
     }, cardReaderEvent: { message in
       guard let message = message else {
@@ -224,31 +189,31 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
       }
       print(message.message)
       if let transactionUpdate = TransactionUpdate(anpMeaningfulMessage: message) {
-        transactionUpdateDelegate?.onTransactionUpdate(transactionUpdate: transactionUpdate)
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.transactionUpdateDelay) {
+          transactionUpdateDelegate?.onTransactionUpdate(transactionUpdate: transactionUpdate)
+          self.transactionUpdateDelay = 0.0
+        }
+      } else {
+        self.transactionUpdateDelay = 2.0
       }
     })
-
   }
-
   func refund(transaction: Transaction, refundAmount: Amount?, completion: @escaping (TransactionResult) -> Void, error: @escaping (OmniException) -> Void) {
     let refund = AnyPayTransaction(type: .REFUND)
     refund?.externalID = transaction.awcExternalId()
     refund?.totalAmount = ANPAmount(string: refundAmount?.dollarsString())
-
-    refund?.execute({ (transactionStatus, error) in
+    refund?.execute({ (transactionStatus, _) in
       print(transactionStatus)
       let result = TransactionResult(refund!)
       completion(result)
     })
   }
-
   func getConnectedReader(completion: (MobileReader?) -> Void, error: @escaping (OmniException) -> Void) {
     guard let reader = ANPCardReaderController.shared().connectedReader else {
       return completion(nil)
     }
     completion(MobileReader.from(anyPayCardReader: reader))
   }
-
   /// Gets the connected MobileReader
   /// - Note: This is blocking, and will fail silently if no reader is found
   /// - Returns: The connected mobile reader, if any
@@ -256,54 +221,44 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
     guard let reader = ANPCardReaderController.shared().connectedReader else {
       return nil
     }
-
     return MobileReader.from(anyPayCardReader: reader)
   }
-
   // MARK: AWC Events
   var onCardReaderConnected: ((AnyPayCardReader?) -> Void)? {
     willSet(newValue) {
       if let onCardReaderConnected = onCardReaderConnected {
         ANPCardReaderController.shared().unsubscribe(onCardReaderConnected: onCardReaderConnected)
       }
-
       if let newValue = newValue {
         ANPCardReaderController.shared().subscribe(onCardReaderConnected: newValue)
       }
     }
   }
-
   var onCardReaderDisconnected: (() -> Void)? {
     willSet(newValue) {
       if let onCardReaderDisconnected = onCardReaderDisconnected {
         ANPCardReaderController.shared().unsubscribe(onCardReaderDisConnected: onCardReaderDisconnected)
       }
-
       if let newValue = newValue {
         ANPCardReaderController.shared().subscribe(onCardReaderDisConnected: newValue)
       }
     }
   }
-
   var onCardReaderConnectionFailed: ((ANPMeaningfulError?) -> Void)? {
     willSet(newValue) {
       if let onCardReaderConnectionFailed = onCardReaderConnectionFailed {
         ANPCardReaderController.shared().unsubscribe(onCardReaderConnectionFailed: onCardReaderConnectionFailed)
       }
-
       if let newValue = newValue {
         ANPCardReaderController.shared().subscribe(onCardReaderConnectionFailed: newValue)
       }
     }
   }
-
   // MARK: CoreBluetooth Central Manager Delegate
-
   /// Does the necessary steps to start search of BT devices
   func startBtService() {
     btCentralManager = CBCentralManager(delegate: self, queue: nil)
   }
-
   /// Begins searching for AWC BT Devices
   ///
   /// The serial numbers of the BT devices will be inserted into `discoveredBluetoothDeviceSerailNumbers` as they
@@ -318,12 +273,10 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
     centralManager.scanForPeripherals(withServices: nil, options: nil)
     return true
   }
-
   /// Stops searching for AWC BT Devices
   func stopBtDeviceSearch() {
     btCentralManager?.stopScan()
   }
-
   func centralManagerDidUpdateState(_ central: CBCentralManager) {
     switch central.state {
     case .unknown:
@@ -340,15 +293,13 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
       print("central.state is .poweredOn")
     }
   }
-
   func centralManager(_ central: CBCentralManager,
                       didDiscover peripheral: CBPeripheral,
-                      advertisementData: [String : Any],
+                      advertisementData: [String: Any],
                       rssi RSSI: NSNumber) {
     guard let serial = peripheral.name, serial.contains("CHB") == true else { return }
     self.discoveredBluetoothDeviceSerialNumbers.insert(serial)
   }
-
 }
 
 #endif

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
@@ -47,6 +47,8 @@ extension TransactionUpdate {
       self = .Authorizing
     } else if message == "Remove Card" {
       self = .PromptRemoveCard
+    } else if message == "Insert Card" {
+      self = .PromptInsertCard
     } else {
       return nil
     }

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionUpdate.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionUpdate.swift
@@ -34,6 +34,7 @@ public struct TransactionUpdate {
 
   public static let PromptInsertSwipeTap = TransactionUpdate("Prompt Insert Swipe Tap Card",
                                                              "Please insert, tap, or swipe card")
+  public static let PromptInsertCard = TransactionUpdate("Prompt Insert Card", "Please insert card")
 
   /// Request card be swiped
   public static let PromptSwipeCard = TransactionUpdate("Prompt Swipe Card", "Please swipe card")

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -17,43 +17,43 @@ enum TakeMobileReaderPaymentException: OmniException {
   case couldNotCreatePaymentMethod(detail: String?)
   case couldNotUpdateInvoice(detail: String?)
   case couldNotCreateTransaction(detail: String?)
-
+  
   static var mess: String = "Error taking mobile reader payment"
-
+  
   var detail: String? {
     switch self {
     case .mobileReaderNotFound:
       return "Mobile reader not found"
-
+      
     case .mobileReaderNotReady:
       return "Mobile reader not ready to take payment"
-
+      
     case .invoiceNotFound:
       return "Invoice with given id not found"
-
+      
     case .couldNotCreateInvoice(let d):
       return d ?? "Could not create invoice"
-
+      
     case .couldNotCreateCustomer(let d):
       return d ?? "Could not create customer"
-
+      
     case .couldNotCreatePaymentMethod(let d):
       return d ?? "Could not create payment method"
-
+      
     case .couldNotUpdateInvoice(let d):
       return d ?? "Could not update invoice"
-
+      
     case .couldNotCreateTransaction(let d):
       return d ?? "Could not create transaction"
     }
   }
-
+  
 }
 
 class TakeMobileReaderPayment {
-
+  
   typealias Exception = TakeMobileReaderPaymentException
-
+  
   var mobileReaderDriverRepository: MobileReaderDriverRepository
   var invoiceRepository: InvoiceRepository
   var customerRepository: CustomerRepository
@@ -62,7 +62,7 @@ class TakeMobileReaderPayment {
   var request: TransactionRequest
   var signatureProvider: SignatureProviding?
   weak var transactionUpdateDelegate: TransactionUpdateDelegate?
-
+  
   init(
     mobileReaderDriverRepository: MobileReaderDriverRepository,
     invoiceRepository: InvoiceRepository,
@@ -72,7 +72,7 @@ class TakeMobileReaderPayment {
     request: TransactionRequest,
     signatureProvider: SignatureProviding?,
     transactionUpdateDelegate: TransactionUpdateDelegate?) {
-
+    
     self.mobileReaderDriverRepository = mobileReaderDriverRepository
     self.invoiceRepository = invoiceRepository
     self.customerRepository = customerRepository
@@ -82,59 +82,59 @@ class TakeMobileReaderPayment {
     self.signatureProvider = signatureProvider
     self.transactionUpdateDelegate = transactionUpdateDelegate
   }
-
+  
   func start(completion: @escaping (Transaction) -> Void, failure: @escaping (OmniException) -> Void) {
     availableMobileReaderDriver(mobileReaderDriverRepository, failure) { driver in
-
+      
       self.getOrCreateInvoice(failure) { (createdInvoice) in
-
+        
         self.takeMobileReaderPayment(with: driver,
                                      signatureProvider: self.signatureProvider,
                                      transactionUpdateDelegate: self.transactionUpdateDelegate,
                                      failure) { (mobileReaderPaymentResult) in
-
-          self.createCustomer(mobileReaderPaymentResult, failure) { (createdCustomer) in
-
-            self.createPaymentMethod(for: createdCustomer, mobileReaderPaymentResult, failure) { (createdPaymentMethod) in
-
-              self.updateInvoice(createdInvoice, with: createdPaymentMethod, and: createdCustomer, failure) { (updatedInvoice) in
-
-                self.createTransaction(
-                  result: mobileReaderPaymentResult,
-                  paymentMethod: createdPaymentMethod,
-                  customer: createdCustomer,
-                  invoice: updatedInvoice,
-                  failure,
-                  completion
-                )
-              }
-            }
-          }
+                                      
+                                      self.createCustomer(mobileReaderPaymentResult, failure) { (createdCustomer) in
+                                        
+                                        self.createPaymentMethod(for: createdCustomer, mobileReaderPaymentResult, failure) { (createdPaymentMethod) in
+                                          
+                                          self.updateInvoice(createdInvoice, with: createdPaymentMethod, and: createdCustomer, failure) { (updatedInvoice) in
+                                            
+                                            self.createTransaction(
+                                              result: mobileReaderPaymentResult,
+                                              paymentMethod: createdPaymentMethod,
+                                              customer: createdCustomer,
+                                              invoice: updatedInvoice,
+                                              failure,
+                                              completion
+                                            )
+                                          }
+                                        }
+                                      }
         }
       }
     }
   }
-
+  
   internal func createTransaction(result: TransactionResult, paymentMethod: PaymentMethod, customer: Customer, invoice: Invoice, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Transaction) -> Void) {
     let transactionToCreate = Transaction()
-
+    
     guard let paymentMethodId = paymentMethod.id else {
       failure(Exception.couldNotUpdateInvoice(detail: "Payment method id is required"))
       return
     }
-
+    
     guard let lastFour = getLastFour(for: result.maskedPan) else {
-        failure(Exception.couldNotCreatePaymentMethod(detail: "Could not retrieve masked pan"))
-        return
+      failure(Exception.couldNotCreatePaymentMethod(detail: "Could not retrieve masked pan"))
+      return
     }
-
+    
     guard let transactionMetaJson = createTransactionMetaJson(from: result) else {
       failure(Exception.couldNotCreateTransaction(detail: "Could not generate transaction meta json"))
       return
     }
-
+    
     var gatewayResponseJson: JSONValue?
-
+    
     if let authCode = result.authCode, result.source.lowercased() == "nmi" {
       let gatewayResponse = [
         "gateway_specific_response_fields": [
@@ -143,20 +143,20 @@ class TakeMobileReaderPayment {
           ]
         ]
       ]
-
+      
       gatewayResponseJson = gatewayResponse.jsonValue()
     }
-
+    
     guard let customerId = customer.id else {
       failure(Exception.couldNotCreateTransaction(detail: "Customer id is required"))
       return
     }
-
+    
     guard let invoiceId = invoice.id else {
       failure(Exception.couldNotCreateTransaction(detail: "Invoice id is required"))
       return
     }
-
+    
     transactionToCreate.paymentMethodId = paymentMethodId
     transactionToCreate.total = request.amount.dollars()
     transactionToCreate.success = result.success ?? false
@@ -170,26 +170,26 @@ class TakeMobileReaderPayment {
     transactionToCreate.response = gatewayResponseJson
     transactionToCreate.token = result.externalId
     transactionToCreate.message = result.message
-
+    
     transactionRepository.create(model: transactionToCreate, completion: completion, error: failure)
   }
-
+  
   /// Creates a JSONValue object that from the transactionResult, including only the items that make up the TransactionMeta
   /// - Parameter transactionResult: the TransactionResult object to be converted into transaction meta
   fileprivate func createTransactionMetaJson(from transactionResult: TransactionResult) -> JSONValue? {
     var dict: [String: String] = [:]
-
+    
     //TODO: Move this somewhere outside the UseCase
     #if !targetEnvironment(simulator)
     if transactionResult.source.contains(ChipDnaDriver.source) {
       if let userRef = transactionResult.userReference {
         dict["nmiUserRef"] = userRef
       }
-
+      
       if let localId = transactionResult.localId {
         dict["cardEaseReference"] = localId
       }
-
+      
       if let externalId = transactionResult.externalId {
         dict["nmiTransactionId"] = externalId
       }
@@ -199,7 +199,7 @@ class TakeMobileReaderPayment {
       }
     }
     #endif
-
+    
     if let gatewayResponse = transactionResult.gatewayResponse {
       dict["gatewayResponse"] = gatewayResponse
     }
@@ -211,37 +211,37 @@ class TakeMobileReaderPayment {
         /// If this fails we don't care
       }
     }
-
+    
     return dict.jsonValue()
   }
-
+  
   fileprivate func updateInvoice(_ invoice: Invoice,
                                  with paymentMethod: PaymentMethod,
                                  and customer: Customer,
                                  _ failure: @escaping (OmniException) -> Void,
                                  completion: @escaping (Invoice) -> Void) {
     let newInvoice = Invoice()
-
+    
     guard let id = invoice.id else {
       failure(Exception.couldNotUpdateInvoice(detail: "Invoice id is required"))
       return
     }
-
+    
     guard let paymentMethodId = paymentMethod.id else {
       failure(Exception.couldNotUpdateInvoice(detail: "Payment method id is required"))
       return
     }
-
+    
     guard let customerId = customer.id else {
       failure(Exception.couldNotUpdateInvoice(detail: "Customer id is required"))
       return
     }
-
+    
     newInvoice.customerId = customerId
     newInvoice.paymentMethodId = paymentMethodId
     invoiceRepository.update(model: newInvoice, id: id, completion: completion, error: failure)
   }
-
+  
   fileprivate func getLastFour(for maskedPan: String?) -> String? {
     guard
       let maskedPan = maskedPan,
@@ -249,28 +249,28 @@ class TakeMobileReaderPayment {
       let lastFourIdx = maskedPan.index(maskedPan.endIndex, offsetBy: -4, limitedBy: maskedPan.startIndex) else {
         return nil
     }
-
+    
     return String(maskedPan.suffix(from: lastFourIdx))
   }
-
+  
   fileprivate func createPaymentMethod(for customer: Customer, _ result: TransactionResult, _ failure: @escaping (OmniException) -> Void, completion: @escaping (PaymentMethod) -> Void) {
     let paymentMethodToCreate = PaymentMethod()
-
+    
     guard let customerId = customer.id else {
       failure(Exception.couldNotCreateCustomer(detail: "Customer id is required"))
       return
     }
-
+    
     guard let lastFour = getLastFour(for: result.maskedPan) else {
       failure(Exception.couldNotCreatePaymentMethod(detail: "Could not retrieve masked pan"))
       return
     }
-
+    
     guard let cardType = result.cardType else {
       failure(Exception.couldNotCreateCustomer(detail: "Card type is required"))
       return
     }
-
+    
     paymentMethodToCreate.cardExp = result.cardExpiration
     paymentMethodToCreate.customerId = customerId
     paymentMethodToCreate.method = PaymentMethodType.card
@@ -279,7 +279,7 @@ class TakeMobileReaderPayment {
     paymentMethodToCreate.personName = "\(customer.firstname ?? "") \(customer.lastname ?? "")"
     paymentMethodToCreate.tokenize = false
     paymentMethodToCreate.paymentToken = result.paymentToken
-
+    
     // When the payment method was tokenized, we want to use the
     // createTokenizedPaymentMethod method since it tells Omni to save the token
     if paymentMethodToCreate.paymentToken != nil {
@@ -287,24 +287,27 @@ class TakeMobileReaderPayment {
     } else {
       paymentMethodRepository.create(model: paymentMethodToCreate, completion: completion, error: failure)
     }
-
+    
   }
-
+  
   fileprivate func createCustomer(_ transactionResult: TransactionResult, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Customer) -> Void) {
     let customerToCreate = Customer()
     customerToCreate.firstname = transactionResult.cardHolderFirstName ?? "SWIPE"
     customerToCreate.lastname = transactionResult.cardHolderLastName ?? "CUSTOMER"
     customerRepository.create(model: customerToCreate, completion: completion, error: failure)
   }
-
+  
   fileprivate func takeMobileReaderPayment(with driver: MobileReaderDriver,
                                            signatureProvider: SignatureProviding?,
                                            transactionUpdateDelegate: TransactionUpdateDelegate?,
                                            _ failure: (OmniException) -> Void,
                                            _ completion: @escaping (TransactionResult) -> Void) {
-    driver.performTransaction(with: self.request, signatureProvider: signatureProvider, transactionUpdateDelegate: transactionUpdateDelegate, completion: completion)
+    driver.performTransaction(with: self.request,
+                              signatureProvider: signatureProvider,
+                              transactionUpdateDelegate: transactionUpdateDelegate,
+                              completion: completion)
   }
-
+  
   /// Gets the invoice with the id in the transaction request or creates a new one
   internal func getOrCreateInvoice(_ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Invoice) -> Void) {
     // If an invoiceId was given in the transaction request, we should verify that an invoice with that id exists
@@ -319,17 +322,17 @@ class TakeMobileReaderPayment {
       let invoiceMeta = [
         "subtotal": self.request.amount.dollarsString()
       ]
-
+      
       guard let invoiceMetaJson = invoiceMeta.jsonValue() else {
         failure(Exception.couldNotCreateInvoice(detail: "Error generating json for meta"))
         return
       }
-
+      
       invoiceToCreate.meta = invoiceMetaJson
       invoiceRepository.create(model: invoiceToCreate, completion: completion, error: failure)
     }
   }
-
+  
   fileprivate func availableMobileReaderDriver(_ repo: MobileReaderDriverRepository, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (MobileReaderDriver) -> Void) {
     repo.getInitializedDrivers { initializedDrivers in
       // Get drivers that are ready for payment
@@ -338,10 +341,10 @@ class TakeMobileReaderPayment {
           failure(TakeMobileReaderPaymentException.mobileReaderNotFound)
           return
         }
-
+        
         completion(driver)
       }
     }
   }
-
+  
 }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -95,14 +95,14 @@ class TakeMobileReaderPayment {
                                                              with: createdPaymentMethod,
                                                              and: createdCustomer,
                                                              failure) { (updatedInvoice) in
-                                            self.createTransaction(
-                                              result: mobileReaderPaymentResult,
-                                              paymentMethod: createdPaymentMethod,
-                                              customer: createdCustomer,
-                                              invoice: updatedInvoice,
-                                              failure,
-                                              completion
-                                            )
+                                                              self.createTransaction(
+                                                                result: mobileReaderPaymentResult,
+                                                                paymentMethod: createdPaymentMethod,
+                                                                customer: createdCustomer,
+                                                                invoice: updatedInvoice,
+                                                                failure,
+                                                                completion
+                                                              )
                                           }
                                         }
                                       }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -17,43 +17,42 @@ enum TakeMobileReaderPaymentException: OmniException {
   case couldNotCreatePaymentMethod(detail: String?)
   case couldNotUpdateInvoice(detail: String?)
   case couldNotCreateTransaction(detail: String?)
-  
+
   static var mess: String = "Error taking mobile reader payment"
-  
+
   var detail: String? {
     switch self {
     case .mobileReaderNotFound:
       return "Mobile reader not found"
-      
+
     case .mobileReaderNotReady:
       return "Mobile reader not ready to take payment"
-      
+
     case .invoiceNotFound:
       return "Invoice with given id not found"
-      
+
     case .couldNotCreateInvoice(let d):
       return d ?? "Could not create invoice"
-      
+
     case .couldNotCreateCustomer(let d):
       return d ?? "Could not create customer"
-      
+
     case .couldNotCreatePaymentMethod(let d):
       return d ?? "Could not create payment method"
-      
+
     case .couldNotUpdateInvoice(let d):
       return d ?? "Could not update invoice"
-      
+
     case .couldNotCreateTransaction(let d):
       return d ?? "Could not create transaction"
     }
   }
-  
 }
 
 class TakeMobileReaderPayment {
-  
+
   typealias Exception = TakeMobileReaderPaymentException
-  
+
   var mobileReaderDriverRepository: MobileReaderDriverRepository
   var invoiceRepository: InvoiceRepository
   var customerRepository: CustomerRepository
@@ -62,7 +61,7 @@ class TakeMobileReaderPayment {
   var request: TransactionRequest
   var signatureProvider: SignatureProviding?
   weak var transactionUpdateDelegate: TransactionUpdateDelegate?
-  
+
   init(
     mobileReaderDriverRepository: MobileReaderDriverRepository,
     invoiceRepository: InvoiceRepository,
@@ -72,7 +71,7 @@ class TakeMobileReaderPayment {
     request: TransactionRequest,
     signatureProvider: SignatureProviding?,
     transactionUpdateDelegate: TransactionUpdateDelegate?) {
-    
+
     self.mobileReaderDriverRepository = mobileReaderDriverRepository
     self.invoiceRepository = invoiceRepository
     self.customerRepository = customerRepository
@@ -82,23 +81,20 @@ class TakeMobileReaderPayment {
     self.signatureProvider = signatureProvider
     self.transactionUpdateDelegate = transactionUpdateDelegate
   }
-  
+
   func start(completion: @escaping (Transaction) -> Void, failure: @escaping (OmniException) -> Void) {
     availableMobileReaderDriver(mobileReaderDriverRepository, failure) { driver in
-      
       self.getOrCreateInvoice(failure) { (createdInvoice) in
-        
         self.takeMobileReaderPayment(with: driver,
                                      signatureProvider: self.signatureProvider,
                                      transactionUpdateDelegate: self.transactionUpdateDelegate,
                                      failure) { (mobileReaderPaymentResult) in
-                                      
                                       self.createCustomer(mobileReaderPaymentResult, failure) { (createdCustomer) in
-                                        
                                         self.createPaymentMethod(for: createdCustomer, mobileReaderPaymentResult, failure) { (createdPaymentMethod) in
-                                          
-                                          self.updateInvoice(createdInvoice, with: createdPaymentMethod, and: createdCustomer, failure) { (updatedInvoice) in
-                                            
+                                          self.updateInvoice(createdInvoice,
+                                                             with: createdPaymentMethod,
+                                                             and: createdCustomer,
+                                                             failure) { (updatedInvoice) in
                                             self.createTransaction(
                                               result: mobileReaderPaymentResult,
                                               paymentMethod: createdPaymentMethod,
@@ -114,27 +110,27 @@ class TakeMobileReaderPayment {
       }
     }
   }
-  
+
   internal func createTransaction(result: TransactionResult, paymentMethod: PaymentMethod, customer: Customer, invoice: Invoice, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Transaction) -> Void) {
     let transactionToCreate = Transaction()
-    
+
     guard let paymentMethodId = paymentMethod.id else {
       failure(Exception.couldNotUpdateInvoice(detail: "Payment method id is required"))
       return
     }
-    
+
     guard let lastFour = getLastFour(for: result.maskedPan) else {
       failure(Exception.couldNotCreatePaymentMethod(detail: "Could not retrieve masked pan"))
       return
     }
-    
+
     guard let transactionMetaJson = createTransactionMetaJson(from: result) else {
       failure(Exception.couldNotCreateTransaction(detail: "Could not generate transaction meta json"))
       return
     }
-    
+
     var gatewayResponseJson: JSONValue?
-    
+
     if let authCode = result.authCode, result.source.lowercased() == "nmi" {
       let gatewayResponse = [
         "gateway_specific_response_fields": [
@@ -143,20 +139,20 @@ class TakeMobileReaderPayment {
           ]
         ]
       ]
-      
+
       gatewayResponseJson = gatewayResponse.jsonValue()
     }
-    
+
     guard let customerId = customer.id else {
       failure(Exception.couldNotCreateTransaction(detail: "Customer id is required"))
       return
     }
-    
+
     guard let invoiceId = invoice.id else {
       failure(Exception.couldNotCreateTransaction(detail: "Invoice id is required"))
       return
     }
-    
+
     transactionToCreate.paymentMethodId = paymentMethodId
     transactionToCreate.total = request.amount.dollars()
     transactionToCreate.success = result.success ?? false
@@ -170,26 +166,26 @@ class TakeMobileReaderPayment {
     transactionToCreate.response = gatewayResponseJson
     transactionToCreate.token = result.externalId
     transactionToCreate.message = result.message
-    
+
     transactionRepository.create(model: transactionToCreate, completion: completion, error: failure)
   }
-  
+
   /// Creates a JSONValue object that from the transactionResult, including only the items that make up the TransactionMeta
   /// - Parameter transactionResult: the TransactionResult object to be converted into transaction meta
   fileprivate func createTransactionMetaJson(from transactionResult: TransactionResult) -> JSONValue? {
     var dict: [String: String] = [:]
-    
+
     //TODO: Move this somewhere outside the UseCase
     #if !targetEnvironment(simulator)
     if transactionResult.source.contains(ChipDnaDriver.source) {
       if let userRef = transactionResult.userReference {
         dict["nmiUserRef"] = userRef
       }
-      
+
       if let localId = transactionResult.localId {
         dict["cardEaseReference"] = localId
       }
-      
+
       if let externalId = transactionResult.externalId {
         dict["nmiTransactionId"] = externalId
       }
@@ -199,7 +195,7 @@ class TakeMobileReaderPayment {
       }
     }
     #endif
-    
+
     if let gatewayResponse = transactionResult.gatewayResponse {
       dict["gatewayResponse"] = gatewayResponse
     }
@@ -211,37 +207,37 @@ class TakeMobileReaderPayment {
         /// If this fails we don't care
       }
     }
-    
+
     return dict.jsonValue()
   }
-  
+
   fileprivate func updateInvoice(_ invoice: Invoice,
                                  with paymentMethod: PaymentMethod,
                                  and customer: Customer,
                                  _ failure: @escaping (OmniException) -> Void,
                                  completion: @escaping (Invoice) -> Void) {
     let newInvoice = Invoice()
-    
+
     guard let id = invoice.id else {
       failure(Exception.couldNotUpdateInvoice(detail: "Invoice id is required"))
       return
     }
-    
+
     guard let paymentMethodId = paymentMethod.id else {
       failure(Exception.couldNotUpdateInvoice(detail: "Payment method id is required"))
       return
     }
-    
+
     guard let customerId = customer.id else {
       failure(Exception.couldNotUpdateInvoice(detail: "Customer id is required"))
       return
     }
-    
+
     newInvoice.customerId = customerId
     newInvoice.paymentMethodId = paymentMethodId
     invoiceRepository.update(model: newInvoice, id: id, completion: completion, error: failure)
   }
-  
+
   fileprivate func getLastFour(for maskedPan: String?) -> String? {
     guard
       let maskedPan = maskedPan,
@@ -249,28 +245,28 @@ class TakeMobileReaderPayment {
       let lastFourIdx = maskedPan.index(maskedPan.endIndex, offsetBy: -4, limitedBy: maskedPan.startIndex) else {
         return nil
     }
-    
+
     return String(maskedPan.suffix(from: lastFourIdx))
   }
-  
+
   fileprivate func createPaymentMethod(for customer: Customer, _ result: TransactionResult, _ failure: @escaping (OmniException) -> Void, completion: @escaping (PaymentMethod) -> Void) {
     let paymentMethodToCreate = PaymentMethod()
-    
+
     guard let customerId = customer.id else {
       failure(Exception.couldNotCreateCustomer(detail: "Customer id is required"))
       return
     }
-    
+
     guard let lastFour = getLastFour(for: result.maskedPan) else {
       failure(Exception.couldNotCreatePaymentMethod(detail: "Could not retrieve masked pan"))
       return
     }
-    
+
     guard let cardType = result.cardType else {
       failure(Exception.couldNotCreateCustomer(detail: "Card type is required"))
       return
     }
-    
+
     paymentMethodToCreate.cardExp = result.cardExpiration
     paymentMethodToCreate.customerId = customerId
     paymentMethodToCreate.method = PaymentMethodType.card
@@ -279,7 +275,7 @@ class TakeMobileReaderPayment {
     paymentMethodToCreate.personName = "\(customer.firstname ?? "") \(customer.lastname ?? "")"
     paymentMethodToCreate.tokenize = false
     paymentMethodToCreate.paymentToken = result.paymentToken
-    
+
     // When the payment method was tokenized, we want to use the
     // createTokenizedPaymentMethod method since it tells Omni to save the token
     if paymentMethodToCreate.paymentToken != nil {
@@ -287,16 +283,16 @@ class TakeMobileReaderPayment {
     } else {
       paymentMethodRepository.create(model: paymentMethodToCreate, completion: completion, error: failure)
     }
-    
+
   }
-  
+
   fileprivate func createCustomer(_ transactionResult: TransactionResult, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Customer) -> Void) {
     let customerToCreate = Customer()
     customerToCreate.firstname = transactionResult.cardHolderFirstName ?? "SWIPE"
     customerToCreate.lastname = transactionResult.cardHolderLastName ?? "CUSTOMER"
     customerRepository.create(model: customerToCreate, completion: completion, error: failure)
   }
-  
+
   fileprivate func takeMobileReaderPayment(with driver: MobileReaderDriver,
                                            signatureProvider: SignatureProviding?,
                                            transactionUpdateDelegate: TransactionUpdateDelegate?,
@@ -307,7 +303,7 @@ class TakeMobileReaderPayment {
                               transactionUpdateDelegate: transactionUpdateDelegate,
                               completion: completion)
   }
-  
+
   /// Gets the invoice with the id in the transaction request or creates a new one
   internal func getOrCreateInvoice(_ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Invoice) -> Void) {
     // If an invoiceId was given in the transaction request, we should verify that an invoice with that id exists
@@ -322,17 +318,17 @@ class TakeMobileReaderPayment {
       let invoiceMeta = [
         "subtotal": self.request.amount.dollarsString()
       ]
-      
+
       guard let invoiceMetaJson = invoiceMeta.jsonValue() else {
         failure(Exception.couldNotCreateInvoice(detail: "Error generating json for meta"))
         return
       }
-      
+
       invoiceToCreate.meta = invoiceMetaJson
       invoiceRepository.create(model: invoiceToCreate, completion: completion, error: failure)
     }
   }
-  
+
   fileprivate func availableMobileReaderDriver(_ repo: MobileReaderDriverRepository, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (MobileReaderDriver) -> Void) {
     repo.getInitializedDrivers { initializedDrivers in
       // Get drivers that are ready for payment
@@ -341,10 +337,9 @@ class TakeMobileReaderPayment {
           failure(TakeMobileReaderPaymentException.mobileReaderNotFound)
           return
         }
-        
+
         completion(driver)
       }
     }
   }
-  
 }

--- a/fattmerchant-ios-sdk/Models/CatalogItem.swift
+++ b/fattmerchant-ios-sdk/Models/CatalogItem.swift
@@ -19,7 +19,7 @@ public struct CatalogItem: Model, Codable {
   public var quantity: Int
   /// The price of the item in dollars
   public var price: Double
-  
+
   public init(id: String?, item: String?, details: String?, quantity: Int, price: Double) {
      self.id = id
      self.item = item


### PR DESCRIPTION
[MOB-102 Request chip cards be inserted for AWC transactions](https://fattmerchant.atlassian.net/browse/MOB-102)

## What is this?
This adds the `PromptInsertCard` transaction update type and also adds a delay between important messages returned by AWC. This allows the end user to be able to see error prompts for longer periods of time.

## What did I do?
• Added `PromptInsertCard` to `TransactionUpdate`
• Added logic for delaying the transaction update from the AWC reader
• Fixed weird whitespace issues from SwiftLint
