### PR TITLE
[SPRINT-148][MOB-115] Transactions need to ingest metadata

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionRequest.swift
@@ -38,26 +38,47 @@ public struct TransactionRequest {
 
   /// The `Amount` to be collected during the transaction
   public var amount: Amount
+
   /// The `CreditCard` to charge
   public var card: CreditCard?
+
   /// The `LineItem`s being passed to the transaction
   public var lineItems: [CatalogItem]?
+
+  /// The subtotal of the transaction
+  public var subtotal: Double?
+
+  /// The tax applied to the transaction
+  public var tax: Double?
+
+  /// The tip amount applied to the transaction
+  public var tip: Double?
+
+  /// A memo for the transaction
+  public var memo: String?
+
+  /// A reference for the transaction
+  public var reference: String?
+
   /// The option to tokenize the payment method for later usage
   ///
   /// - Note: Defaults to true
   ///
   /// Set this to false if you do not want the payment method stored
   public var tokenize: Bool = true
+
   /// The id of the invoice that this payment should be applied to
   ///
   /// If nil, then a new invoice will be created
   public var invoiceId: String?
+
   /// Initializes a TransactionRequest with the given amount.
   ///
   /// - Parameter amount: The  `Amount` to be collected during the transaction
   public init(amount: Amount) {
     self.amount = amount
   }
+
   /// Initializes a TransactionRequest with the given amount.
   ///
   /// - Parameter amount: The  `Amount` to be collected during the transaction
@@ -65,6 +86,7 @@ public struct TransactionRequest {
     self.amount = amount
     self.card = card
   }
+
   /// Initializes a TransactionRequest with the given amount and explicitly sets the tokenize value
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction
@@ -74,6 +96,7 @@ public struct TransactionRequest {
     self.amount = amount
     self.tokenize = tokenize
   }
+
   /// Initializes a TransactionRequest with the given amount and explicitly sets the tokenize value
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction
@@ -85,6 +108,7 @@ public struct TransactionRequest {
     self.tokenize = tokenize
     self.card = card
   }
+
   /// Initializes a TransactionRequest with the given amount and explicitly sets the tokenize value
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction
@@ -96,6 +120,7 @@ public struct TransactionRequest {
     self.tokenize = tokenize
     self.invoiceId = invoiceId
   }
+
   /// Initializes a TransactionRequest with the given amount and a list of line items
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction
@@ -104,6 +129,7 @@ public struct TransactionRequest {
     self.amount = amount
     self.lineItems = lineItems
   }
+
   /// Initializes a TransactionRequest with the given amount and a list of line items
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction
@@ -114,6 +140,7 @@ public struct TransactionRequest {
     self.card = card
     self.lineItems = lineItems
   }
+
   /// Initializes a TransactionRequest with the given amount, explicitly sets the tokenize value and a contains a list of line items
   /// - Parameters:
   ///   - amount: The `Amount` to be collected during the transaction

--- a/fattmerchant-ios-sdk/Cardpresent/JSON/JSONValue.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/JSON/JSONValue.swift
@@ -141,6 +141,20 @@ public enum JSONValue: Codable, Equatable {
     return nil
   }
 
+  subscript(key: String) -> Double? {
+    if case let JSONValue.object(dict) = self, dict.keys.contains(key) {
+      guard
+        let val = dict[key],
+        val != nil,
+        case let JSONValue.double(i) = val!
+        else {
+          return nil
+      }
+      return i
+    }
+    return nil;
+  }
+
   subscript(key: String) -> String? {
     if case let JSONValue.object(dict) = self, dict.keys.contains(key) {
       guard

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -198,9 +198,31 @@ class TakeMobileReaderPayment {
     if let gatewayResponse = transactionResult.gatewayResponse {
       dict["gatewayResponse"] = JSONValue(gatewayResponse)
     }
+
     if let lineItemResponse = transactionResult.request?.lineItems {
       dict["lineItems"] = JSONValue(lineItemResponse)
     }
+
+    if let subtotal = transactionResult.request?.subtotal {
+      dict["subtotal"] = JSONValue(subtotal)
+    }
+
+    if let tax = transactionResult.request?.tax {
+      dict["tax"] = JSONValue(tax)
+    }
+
+    if let memo = transactionResult.request?.memo {
+      dict["memo"] = JSONValue(memo)
+    }
+
+    if let reference = transactionResult.request?.reference {
+      dict["reference"] = JSONValue(reference)
+    }
+
+    if let tip = transactionResult.request?.tip {
+      dict["tip"] = JSONValue(tip)
+    }
+
     return dict.jsonValue()
   }
 

--- a/fattmerchant_ios_sdkTests/Usecase/TakeMobileReaderPaymentTests.swift
+++ b/fattmerchant_ios_sdkTests/Usecase/TakeMobileReaderPaymentTests.swift
@@ -198,4 +198,39 @@ class TakeMobileReaderPaymentTests: XCTestCase {
     wait(for: [expectation], timeout: 10.0)
   }
 
+  func testTransactionRequestWithExtraMeta() {
+    var transactionRequest = TransactionRequest(amount: Amount(cents: 1))
+    transactionRequest.subtotal = 0.01
+    transactionRequest.tax = 0
+    transactionRequest.tip = 0
+    transactionRequest.memo = "This transaction is so great!"
+    transactionRequest.reference = "1478"
+
+    let job = TakeMobileReaderPayment(
+      mobileReaderDriverRepository: mobileReaderDriverRepo,
+      invoiceRepository: invoiceRepo,
+      customerRepository: customerRepo,
+      paymentMethodRepository: paymentMethodRepo,
+      transactionRepository: transactionRepo,
+      request: transactionRequest,
+      signatureProvider: nil,
+      transactionUpdateDelegate: nil
+    )
+
+    let expectation = XCTestExpectation(description: "Result of transaction has the expected meta data")
+
+      job.start(completion: { transaction in
+        XCTAssertEqual(transaction.meta?["subtotal"] as Double?, 0.01)
+        XCTAssertEqual(transaction.meta?["tax"] as Double?, 0)
+        XCTAssertEqual(transaction.meta?["tip"] as Double?, 0)
+        XCTAssertEqual(transaction.meta?["memo"] as String?, "This transaction is so great!")
+        XCTAssertEqual(transaction.meta?["reference"] as String?, "1478")
+        expectation.fulfill()
+      }) { error in
+        XCTFail("Transaction failed")
+      }
+
+      wait(for: [expectation], timeout: 10.0)
+  }
+
 }


### PR DESCRIPTION
[MOB-115 Transactions need to ingest metadata](https://fattmerchant.atlassian.net/browse/MOB-115)

## What is this?
Transactions were not including required metadata fields

## What did I do?
• Added required metadata fields to `TransactionRequest`
• Wrote a test to validate that metadata is returned properly in result
