### PR TITLE
[MOB-121] Pass in "channel": "ios" on invoice and transaction POST/PUT

### DIFF
--- a/fattmerchant-ios-sdk/Models/Invoice.swift
+++ b/fattmerchant-ios-sdk/Models/Invoice.swift
@@ -33,5 +33,4 @@ class Invoice: Model {
   public var url: String?
   public var userId: String?
   public var viewedAt: String?
-  var channel: String = "ios"
 }

--- a/fattmerchant-ios-sdk/Models/Invoice.swift
+++ b/fattmerchant-ios-sdk/Models/Invoice.swift
@@ -33,4 +33,5 @@ class Invoice: Model {
   public var url: String?
   public var userId: String?
   public var viewedAt: String?
+  var channel: String = "ios"
 }

--- a/fattmerchant-ios-sdk/Models/Transaction.swift
+++ b/fattmerchant-ios-sdk/Models/Transaction.swift
@@ -99,6 +99,7 @@ public class Transaction: Model, Codable {
   var sourceIp: String?
   var response: JSONValue?
   var updatedAt: String?
+  var channel: String = "ios"
 
   public func getLineItems() -> [CatalogItem]? {
     if let dict = meta?.toDictionary() {

--- a/fattmerchant_ios_sdkTests/Raw Json/TransactionJson.swift
+++ b/fattmerchant_ios_sdkTests/Raw Json/TransactionJson.swift
@@ -16,6 +16,7 @@ let transactionjson =
     "auth_id": null,
     "type": "refund",
     "source": "Android|CPSDK|NMI",
+    "channel": "ios",
     "source_ip": "45.27.255.121",
     "is_merchant_present": true,
     "merchant_id": "a61d78cc-cde9-44ac-8a18-30c39be05879",


### PR DESCRIPTION
[MOB-121 Pass in "channel": "ios" on invoice and transaction POST/PUT](https://fattmerchant.atlassian.net/browse/MOB-121)

## What is this?
Transactions and Invoices were not including channel field.

## What did I do?
• Added required channel fields to `Transaction` and `Invoice`

## Screenshots/GIFs
<img width="1430" alt="Screen Shot 2020-09-15 at 3 08 13 PM" src="https://user-images.githubusercontent.com/10945265/93254092-ce1d3680-f765-11ea-8e1e-5e962ddc639b.png">
