### PR TITLE
[MOB-41] iOS SDK | AWC Transaction should be marked not refundable

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -380,7 +380,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
     }
 
     // If no reader was connected, pass nil
-    if (parameters[CCParamResult] != CCValueTrue) {
+    if parameters[CCParamResult] != CCValueTrue {
       didConnectAndConfigure(nil)
     }
 

--- a/fattmerchant-ios-sdk/Cardpresent/JSON/JSONValue.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/JSON/JSONValue.swift
@@ -152,7 +152,7 @@ public enum JSONValue: Codable, Equatable {
       }
       return i
     }
-    return nil;
+    return nil
   }
 
   subscript(key: String) -> String? {

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/CancelCurrentTransaction.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/CancelCurrentTransaction.swift
@@ -45,11 +45,11 @@ class CancelCurrentTransaction {
           driver.cancelCurrentTransaction(completion: { cancelled in
             success = success && cancelled
             semaphore?.signal()
-          }) { err in
+          }, error: { err in
             omniException = err
             success = false
             semaphore?.signal()
-          }
+          })
         }
 
         if let exception = omniException {

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -112,7 +112,13 @@ class TakeMobileReaderPayment {
     }
   }
 
-  internal func createTransaction(result: TransactionResult, driver: MobileReaderDriver, paymentMethod: PaymentMethod, customer: Customer, invoice: Invoice, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Transaction) -> Void) {
+  internal func createTransaction(result: TransactionResult,
+                                  driver: MobileReaderDriver,
+                                  paymentMethod: PaymentMethod,
+                                  customer: Customer,
+                                  invoice: Invoice,
+                                  _ failure: @escaping (OmniException) -> Void,
+                                  _ completion: @escaping (Transaction) -> Void) {
     let transactionToCreate = Transaction()
 
     guard let paymentMethodId = paymentMethod.id else {
@@ -184,7 +190,7 @@ class TakeMobileReaderPayment {
   /// - Parameter transactionResult: the TransactionResult object to be converted into transaction meta
   fileprivate func createTransactionMeta(from transactionResult: TransactionResult) -> JSONValue? {
     var dict = [String: JSONValue?]()
-    //TODO: Move this somewhere outside the UseCase
+
     #if !targetEnvironment(simulator)
     if transactionResult.source.contains(ChipDnaDriver.source) {
       if let userRef = transactionResult.userReference {
@@ -333,7 +339,7 @@ class TakeMobileReaderPayment {
   internal func getOrCreateInvoice(_ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Invoice) -> Void) {
     // If an invoiceId was given in the transaction request, we should verify that an invoice with that id exists
     if let invoiceId = request.invoiceId {
-      invoiceRepository.getById(id: invoiceId, completion: completion) { (error) in
+      invoiceRepository.getById(id: invoiceId, completion: completion) { _ in
         failure(TakeMobileReaderPaymentException.invoiceNotFound)
       }
     } else {
@@ -357,14 +363,14 @@ class TakeMobileReaderPayment {
   fileprivate func availableMobileReaderDriver(_ repo: MobileReaderDriverRepository, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (MobileReaderDriver) -> Void) {
     repo.getInitializedDrivers { initializedDrivers in
       // Get drivers that are ready for payment
-      filter(items: initializedDrivers, predicate: { $0.isReadyToTakePayment }) { driversReadyForPayment in
+      filter(items: initializedDrivers, predicate: { $0.isReadyToTakePayment }, completion: { driversReadyForPayment in
         guard let driver = driversReadyForPayment.first else {
           failure(TakeMobileReaderPaymentException.mobileReaderNotFound)
           return
         }
 
         completion(driver)
-      }
+      })
     }
   }
 }

--- a/fattmerchant-ios-sdk/Models/MobileReader.swift
+++ b/fattmerchant-ios-sdk/Models/MobileReader.swift
@@ -28,7 +28,7 @@ public class MobileReader: CustomStringConvertible {
   public var serialNumber: String?
 
   /// The way that the iOS device connects to the reader. Bluetooth, BLE, etc
-  internal var connectionType: String? = nil
+  internal var connectionType: String?
 
   /// Initialize a MobileReader by name
   ///


### PR DESCRIPTION
## What is this
AWC refunds will not work in the VT. In order to enable this functionality, we’d have to build the void/refund logic specific to AWC in Omni Gateway the same way we built it for NMI. Since we don’t want to do that, we want to mark the AWC transactions as not_refundable or something like that so that the VT/API does not attempt the refund. 

## What did I do?
Set the isRefundable and isVoidable property of new transactions to false if Omni does not have a deep integration with the corresponding platform that the transaction was run on