### PR TITLE
[MOB-283] Fix crash with AWC when blank cardholder name is used

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
@@ -105,14 +105,11 @@ extension TransactionResult {
     if let approvalCode = anyPayTransaction.approvalCode {
       self.authCode = approvalCode
     }
-    if let cardHolderName = anyPayTransaction.cardHolderName{
+    if let cardHolderName = anyPayTransaction.cardHolderName, !cardHolderName.isEmpty {
       var name = cardHolderName.split(separator: " ")
-      if name.count > 0 {
+      if !name.isEmpty {
         self.cardHolderFirstName = String(name.removeFirst())
-
-        if name.count > 1 {
-          self.cardHolderLastName = name.joined(separator: " ")
-        }
+        self.cardHolderLastName = name.joined(separator: " ")
       }
     }
     self.success = anyPayTransaction.status == .APPROVED

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
@@ -105,10 +105,15 @@ extension TransactionResult {
     if let approvalCode = anyPayTransaction.approvalCode {
       self.authCode = approvalCode
     }
-    if let cardHolderName = anyPayTransaction.cardHolderName {
+    if let cardHolderName = anyPayTransaction.cardHolderName{
       var name = cardHolderName.split(separator: " ")
-      self.cardHolderFirstName = String(name.removeFirst())
-      self.cardHolderLastName = name.joined(separator: " ")
+      if name.count > 0 {
+        self.cardHolderFirstName = String(name.removeFirst())
+
+        if name.count > 1 {
+          self.cardHolderLastName = name.joined(separator: " ")
+        }
+      }
     }
     self.success = anyPayTransaction.status == .APPROVED
     self.transactionType = TransactionType(anyPayTransaction.transactionType).rawValue


### PR DESCRIPTION
## What is this?
There is a crash when AWC gets a blank cardholdername for a gift card. The offending code is the following block:

```swift
if let cardHolderName = anyPayTransaction.cardHolderName { // 1
    var name = cardHolderName.split(separator: " ") // 2
    self.cardHolderFirstName = String(name.removeFirst()) // 3
    self.cardHolderLastName = name.joined(separator: " ")
}
```

`1`: Note that `1` is checking for `cardHolderName` to exist and not for blankness. The crash bug happens when `anyPayTransaction.cardHolderName` is `""`. We pass the `if let`, and move onto the next line. 

`2`: We then split the array on `" "`, which doesn't fail, but it then assigns `[]` to `name`, since `split(:)` returns an `[Substring]` but this string is actually empty.  

`3`: At this point, we try to `removeFirst()` from an empty array, which throws a fatal exception. 

## What did I do?
I added some checks to that `if let` so that we don't try to `removeFirst()` from an empty array