### PR TITLE
[MOB-286] Make AWC refund total positive

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
@@ -88,7 +88,16 @@ extension TransactionResult {
     self.source = AWCDriver.source
 
     if let amount = anyPayTransaction.approvedAmount {
-      self.amount = Amount(amount)
+      // AWC seems to return a negative approvedAmount for REFUNDS, so we have to take the absolute value
+      // This is because this amount gets assigned to the "total_refunded" field in Omni sees the negative
+      // and that value is not negative
+      if anyPayTransaction.transactionType == .REFUND {
+        let amt = Amount(amount)
+        let correctedAmount = Amount(cents: abs(amt.cents))
+        self.amount = correctedAmount
+      } else {
+        self.amount = Amount(amount)
+      }
     }
     if let refTransactionId = anyPayTransaction.refTransactionID {
       self.externalId = refTransactionId


### PR DESCRIPTION
https://fattmerchant.atlassian.net/browse/MOB-286

## What is this?
AWC changed the way they give us refund totals. They are now returning a negative refunded_amount and we have to turn it into a positive number because thats what omni expects

## What did I do?
For refund transactions only, we take the absolute value of the `approvedAmount` from AWC