### PR TITLE
[MOB-339] Change tokenization to use POST /payment-method

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -221,6 +221,38 @@ public class Omni: NSObject {
     job.start(completion: completion, failure: error)
   }
 
+  /// Creates a Fattmerchant PaymentMethod out of the given CreditCard
+  ///
+  /// - Parameters:
+  ///   - card: The CreditCard to be tokenized
+  ///   - completion: Called when the operation is completed successfully. Receives a PaymentMethod
+  ///   - error: Receives any errors that happened while attempting the operation
+  public func tokenize(card: CreditCard, completion: @escaping (PaymentMethod) -> Void, error: @escaping (OmniException) -> Void) {
+    let job = TokenizePaymentMethod(
+      customerRepository: customerRepository,
+      paymentMethodRepository: paymentMethodRepository,
+      creditCard: card
+    )
+
+    job.start(completion: completion, failure: error)
+  }
+
+  /// Creates a Fattmerchant PaymentMethod out of the given BankAccount
+  ///
+  /// - Parameters:
+  ///   - bankAccount: The BankAccount to be tokenized
+  ///   - completion: Called when the operation is completed successfully. Receives a PaymentMethod
+  ///   - error: Receives any errors that happened while attempting the operation
+  public func tokenize(bankAccount: BankAccount, completion: @escaping (PaymentMethod) -> Void, error: @escaping (OmniException) -> Void) {
+    let job = TokenizePaymentMethod(
+      customerRepository: customerRepository,
+      paymentMethodRepository: paymentMethodRepository,
+      bankAccount: bankAccount
+    )
+
+    job.start(completion: completion, failure: error)
+  }
+
   /// Captures a mobile reader transaction
   ///
   /// - Note: `Omni` should be assigned a `SignatureProviding` object by the time this transaction is called. This

--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -217,7 +217,7 @@ public class Omni: NSObject {
       return
     }
 
-    let job = TakePayment(request: transactionRequest, omniApi: omniApi, merchant: merchant)
+    let job = TakePayment(request: transactionRequest, customerRepository: customerRepository, paymentMethodRepository: paymentMethodRepository)
     job.start(completion: completion, failure: error)
   }
 

--- a/fattmerchant-ios-sdk/Cardpresent/Repository/CustomerRepository.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Repository/CustomerRepository.swift
@@ -9,14 +9,18 @@
 import Foundation
 
 enum CreateCustomerException: OmniException {
-  case Something(String)
+  case customerNameNotSupplied
+  case unknown
 
   static var mess = "Could not create customer"
 
   var detail: String? {
     switch self {
-    case .Something(let desc):
-      return desc
+    case .customerNameNotSupplied:
+      return "Customer name is required"
+
+    default:
+      return "Unknown error creating customer"
     }
   }
 

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TokenizePaymentMethod.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TokenizePaymentMethod.swift
@@ -22,27 +22,32 @@ class TokenizePaymentMethod {
 
   typealias Exception = TokenizePaymentMethodException
 
-  /// Responsible for communicating with Omni
-  var omniApi: OmniApi
-
-  /// The Merchant that will be associated with the tokenized payment method
-  var merchant: Merchant
-
   /// The card to tokenize. If supplied, bankAccount must be nil
-  var creditCard: CreditCard?
+  private var creditCard: CreditCard?
 
   /// The bank account to tokenize. If supplied, creditCard must be nil
-  var bankAccount: BankAccount?
+  private var bankAccount: BankAccount?
+  private var customerRepository: CustomerRepository
+  private var paymentMethodRepository: PaymentMethodRepository
 
-  var customerRepository: CustomerRepository
-  var paymentMethodRepository: PaymentMethodRepository
+  init(customerRepository: CustomerRepository,
+       paymentMethodRepository: PaymentMethodRepository,
+       creditCard: CreditCard
+  ) {
+    self.creditCard = creditCard
+    self.customerRepository = customerRepository
+    self.paymentMethodRepository = paymentMethodRepository
+    self.bankAccount = nil
+  }
 
-  /// Initializes a TokenizePaymentMethod instance with OmniApi and Merchant
-  init(omniApi: OmniApi, merchant: Merchant) {
-    self.omniApi = omniApi
-    self.merchant = merchant
-    customerRepository = CustomerRepository(omniApi: omniApi)
-    paymentMethodRepository = PaymentMethodRepository(omniApi: omniApi)
+  init(customerRepository: CustomerRepository,
+       paymentMethodRepository: PaymentMethodRepository,
+       bankAccount: BankAccount
+  ) {
+    self.creditCard = nil
+    self.customerRepository = customerRepository
+    self.paymentMethodRepository = paymentMethodRepository
+    self.bankAccount = bankAccount
   }
 
   func start(completion: @escaping (PaymentMethod) -> Void, failure: @escaping (OmniException) -> Void) {

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TokenizePaymentMethod.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TokenizePaymentMethod.swift
@@ -14,6 +14,7 @@ enum TokenizePaymentMethodException: OmniException {
   case tokenizationError
   case couldNotParsePaymentMethodError
   case merchantMissingHostedPaymentsToken
+  case noCreditCardOrBankAccountSupplied
 }
 
 /// Tokenizes a payment method
@@ -27,38 +28,63 @@ class TokenizePaymentMethod {
   /// The Merchant that will be associated with the tokenized payment method
   var merchant: Merchant
 
+  /// The card to tokenize. If supplied, bankAccount must be nil
+  var creditCard: CreditCard?
+
+  /// The bank account to tokenize. If supplied, creditCard must be nil
+  var bankAccount: BankAccount?
+
+  var customerRepository: CustomerRepository
+  var paymentMethodRepository: PaymentMethodRepository
+
   /// Initializes a TokenizePaymentMethod instance with OmniApi and Merchant
   init(omniApi: OmniApi, merchant: Merchant) {
     self.omniApi = omniApi
     self.merchant = merchant
+    customerRepository = CustomerRepository(omniApi: omniApi)
+    paymentMethodRepository = PaymentMethodRepository(omniApi: omniApi)
   }
 
-  func start<T: Codable>(codablePaymentMethod: T, completion: @escaping (PaymentMethod) -> Void, failure: @escaping (OmniException) -> Void) {
-    guard let hostedPaymentsToken = merchant.hostedPaymentsToken else {
-      failure(Exception.merchantMissingHostedPaymentsToken)
-      return
+  func start(completion: @escaping (PaymentMethod) -> Void, failure: @escaping (OmniException) -> Void) {
+
+    guard let customerName = creditCard?.personName ?? bankAccount?.personName else {
+      return failure(CreateCustomerException.customerNameNotSupplied)
     }
-    tokenize(codablePaymentMethod, webpaymentsToken: hostedPaymentsToken, completion: completion, failure: failure)
+
+    createCustomer(customerName) { (customer, error) in
+      guard error == nil, let customer = customer else {
+        return failure(error ?? CreateCustomerException.unknown)
+      }
+
+      var paymentMethod: PaymentMethod
+
+      if let card = self.creditCard {
+        paymentMethod = PaymentMethod(card: card, customer: customer)
+      } else if let bank = self.bankAccount {
+        paymentMethod = PaymentMethod(bank: bank, customer: customer)
+      } else {
+        return failure(TokenizePaymentMethodException.noCreditCardOrBankAccountSupplied)
+      }
+
+      self.paymentMethodRepository.create(model: paymentMethod, completion: completion, error: failure)
+    }
   }
 
-  private func tokenize<T: Codable>(_ codablePaymentMethod: T, webpaymentsToken: String, completion: @escaping (PaymentMethod) -> Void, failure: @escaping (TokenizePaymentMethodException) -> Void) {
-    guard let data = encode(codablePaymentMethod: codablePaymentMethod) else {
-      failure(.couldNotParsePaymentMethodError)
-      return
-    }
-
-    let path = "/webpayment/\(webpaymentsToken)/tokenize"
-
-    omniApi.request(method: "post", urlString: path, body: data, completion: completion) { _ in
-      failure(.couldNotParsePaymentMethodError)
-    }
-
+  private func createCustomer(_ card: CreditCard, completion: @escaping (Customer?, OmniException?) -> Void) {
+    createCustomer(card.personName, completion: completion)
   }
 
-  internal func encode<T: Codable>(codablePaymentMethod: T) -> Data? {
-    let encoder = JSONEncoder()
-    encoder.keyEncodingStrategy = .convertToSnakeCase
-    return try? encoder.encode(codablePaymentMethod)
+  private func createCustomer(_ bankAccount: BankAccount, completion: @escaping (Customer?, OmniException?) -> Void) {
+    createCustomer(bankAccount.personName, completion: completion)
+  }
+
+  private func createCustomer(_ name: String, completion: @escaping (Customer?, OmniException?) -> Void) {
+    let customerToCreate = Customer(fullName: name)
+    customerRepository.create(model: customerToCreate) { (createdCustomer) in
+      completion(createdCustomer, nil)
+    } error: { (error) in
+      completion(nil, error)
+    }
   }
 
 }

--- a/fattmerchant-ios-sdk/Models/Customer.swift
+++ b/fattmerchant-ios-sdk/Models/Customer.swift
@@ -33,6 +33,8 @@ public class Customer: Model {
     return Customer.joinName(first: firstname ?? "", last: lastname ?? "")
   }
 
+  init() {}
+
   /// Initializes a Customer with the full name
   ///
   /// This takes the full name and splits it into first and last

--- a/fattmerchant-ios-sdk/Models/Customer.swift
+++ b/fattmerchant-ios-sdk/Models/Customer.swift
@@ -28,4 +28,42 @@ public class Customer: Model {
   public var phone: String?
   public var reference: String?
   public var updatedAt: String?
+
+  func fullName() -> String {
+    return Customer.joinName(first: firstname ?? "", last: lastname ?? "")
+  }
+
+  /// Initializes a Customer with the full name
+  ///
+  /// This takes the full name and splits it into first and last
+  /// - Parameter fullName: the customers full name
+  init(fullName: String) {
+    let names = Customer.splitName(fullName)
+    self.firstname = names.first
+    self.lastname = names.last
+  }
+
+  /// Takes a full name and splits it into first and last
+  ///
+  /// This is the opposite of joinName
+  /// - Parameter name: the full name
+  /// - Returns: a tuple containing the first and last names
+  static func splitName(_ name: String) -> (first: String, last: String) {
+    var first = ""
+    var last = ""
+    var name = name.split(separator: " ")
+    if !name.isEmpty {
+      first = String(name.removeFirst())
+      last = name.joined(separator: " ")
+    }
+
+    return (first, last)
+  }
+
+  /// Takes a first and last name and joins it into one full name
+  ///
+  /// This is the opposite of splitName
+  static func joinName(first: String, last: String) -> String {
+    return "\(first) \(last)"
+  }
 }

--- a/fattmerchant-ios-sdk/Models/PaymentMethod.swift
+++ b/fattmerchant-ios-sdk/Models/PaymentMethod.swift
@@ -1,3 +1,4 @@
+
 //
 //  PaymentMethod.swift
 //  fattmerchant-ios-sdk
@@ -45,6 +46,14 @@ public class PaymentMethod: Model {
   ///
   /// - Note: If this field is not `null`, then `tokenize` must be `false`
   internal var paymentToken: String?
+  internal var cardNumber: String?
+  internal var cardCvv: String?
+
+  /// The bank account number
+  internal var bankAccount: String?
+
+  /// The bank routing number
+  internal var bankRouting: String?
   public var nickname: String?
   public var personName: String?
   public var cardType: String?
@@ -53,5 +62,23 @@ public class PaymentMethod: Model {
   public var bankName: String?
   public var bankType: String?
   public var bankHolderType: BankHolderType?
+
+  init(card: CreditCard, customer: Customer) {
+    self.customerId = customer.id
+    personName = customer.fullName()
+    method = .card
+    cardNumber = card.cardNumber
+    cardExp = card.cardExp
+  }
+
+  init(bank: BankAccount, customer: Customer) {
+    self.customerId = customer.id
+    personName = customer.fullName()
+    method = .bank
+    bankAccount = bank.bankAccount
+    bankRouting = bank.bankRouting
+    bankName = bank.bankName
+    bankType = bank.bankType
+  }
 
 }

--- a/fattmerchant-ios-sdk/Models/PaymentMethod.swift
+++ b/fattmerchant-ios-sdk/Models/PaymentMethod.swift
@@ -63,6 +63,8 @@ public class PaymentMethod: Model {
   public var bankType: String?
   public var bankHolderType: BankHolderType?
 
+  init() {}
+
   init(card: CreditCard, customer: Customer) {
     self.customerId = customer.id
     personName = customer.fullName()

--- a/fattmerchant_ios_sdkTests/Usecase/TakePaymentTests.swift
+++ b/fattmerchant_ios_sdkTests/Usecase/TakePaymentTests.swift
@@ -12,16 +12,21 @@ class TakePaymentTests: XCTestCase {
 
   var merchant = Merchant()
   var omniApi = MockOmniApi()
+  var customerRepo: CustomerRepository!
+  var paymentMethodRepo: PaymentMethodRepository!
+
 
   override func setUp() {
     merchant = Merchant()
     merchant.hostedPaymentsToken = "hostedpaymentstoken"
     omniApi = MockOmniApi()
+    customerRepo = CustomerRepository(omniApi: omniApi)
+    paymentMethodRepo = PaymentMethodRepository(omniApi: omniApi)
   }
 
   func testCanInitialize() {
     let req = TransactionRequest(amount: Amount(cents: 10))
-    let takePayment = TakePayment(request: req, omniApi: OmniApi(), merchant: Merchant())
+    let takePayment = TakePayment(request: req, customerRepository: customerRepo, paymentMethodRepository: paymentMethodRepo)
     XCTAssertNotNil(takePayment)
   }
 
@@ -40,20 +45,35 @@ class TakePaymentTests: XCTestCase {
   }
 
   func testCanTakePayment() {
-    let card = CreditCard.testCreditCard()
+    modelStore = [:]
+    var card = CreditCard.testCreditCard()
+    card.personName = "Bob Will"
     let amount = Amount(cents: 10)
     let transactionRequest = TransactionRequest(amount: amount, card: card)
     let transaction = Transaction()
     transaction.id = "transactionid"
 
+    // Stub out customer
+    let customer = Customer()
+    customer.firstname = "Bob"
+    customer.lastname = "Will"
+    customer.id = "customer_id_bobwill"
+    let createCustomerBody = try! omniApi.jsonEncoder().encode(customer)
+    omniApi.stub("post", "/customer", body: createCustomerBody, response: .success(customer))
+
     // Stub out payment method
-    let body = try! omniApi.jsonEncoder().encode(card)
     let paymentMethod = PaymentMethod()
-    paymentMethod.id = "123"
-    omniApi.stub("post", "/webpayment/hostedpaymentstoken/tokenize", body: body, response: .success(paymentMethod))
+    paymentMethod.customerId = "customer_id_bobwill"
+    paymentMethod.personName = "Bob Will"
+    paymentMethod.method = .card
+    paymentMethod.cardNumber = card.cardNumber
+    paymentMethod.cardExp = card.cardExp
+    let createPaymentMethodBody = try! omniApi.jsonEncoder().encode(paymentMethod)
+    paymentMethod.id = "payment_method_id_bob_will"
+    omniApi.stub("post", "/payment-method", body: createPaymentMethodBody, response: .success(paymentMethod))
 
     // Stub out charge
-    let chargeRequest = ChargeRequest(paymentMethodId: "123", total: "0.10", meta: [
+    let chargeRequest = ChargeRequest(paymentMethodId: "payment_method_id_bob_will", total: "0.10", meta: [
       "subtotal": "0.10"
     ])
     let chargeBody = Data(chargeRequest: chargeRequest)
@@ -61,7 +81,8 @@ class TakePaymentTests: XCTestCase {
 
     // Perform operation
     let paymentSuccessful = XCTestExpectation(description: "Successful payment")
-    TakePayment(request: transactionRequest, omniApi: omniApi, merchant: merchant).start(completion: { completedTrans in
+    TakePayment(request: transactionRequest, customerRepository: customerRepo, paymentMethodRepository: paymentMethodRepo)
+      .start(completion: { completedTrans in
       XCTAssertNotNil(completedTrans)
       XCTAssertEqual(transaction.id, completedTrans.id)
       paymentSuccessful.fulfill()
@@ -74,7 +95,7 @@ class TakePaymentTests: XCTestCase {
 
   func testFailsWhenNoPaymentMethodGiven() {
     let req = TransactionRequest(amount: Amount(cents: 10))
-    let takePayment = TakePayment(request: req, omniApi: MockOmniApi(), merchant: Merchant())
+    let takePayment = TakePayment(request: req, customerRepository: customerRepo, paymentMethodRepository: paymentMethodRepo)
 
     let exception = XCTestExpectation(description: "TakePayment fails because no card was provided")
 
@@ -96,7 +117,7 @@ class TakePaymentTests: XCTestCase {
     let badCard = CreditCard(personName: "", cardNumber: "", cardExp: "", addressZip: "")
     let amount = Amount(cents: 10)
     let transactionRequest = TransactionRequest(amount: amount, card: badCard)
-    let takePayment = TakePayment(request: transactionRequest, omniApi: omniApi, merchant: merchant)
+    let takePayment = TakePayment(request: transactionRequest, customerRepository: customerRepo, paymentMethodRepository: paymentMethodRepo)
     let expectedError = TokenizePaymentMethodException.couldNotParsePaymentMethodError
 
     // Stub out the tokenize call
@@ -120,7 +141,7 @@ class TakePaymentTests: XCTestCase {
     let badCard = CreditCard(personName: "Jane Tester", cardNumber: "4111111111111111", cardExp: "123", addressZip: "32823")
     let amount = Amount(cents: 10)
     let transactionRequest = TransactionRequest(amount: amount, card: badCard)
-    let takePayment = TakePayment(request: transactionRequest, omniApi: omniApi, merchant: merchant)
+    let takePayment = TakePayment(request: transactionRequest, customerRepository: customerRepo, paymentMethodRepository: paymentMethodRepo)
 
     // Create bad payment method
     let paymentMethodWithoutId = PaymentMethod()


### PR DESCRIPTION
## What is this
The old way of doing tokenization was with webpayments/{:id}/tokenize. However, we don't want to use that anymore and prefer POST payment-method.

## What did I do
- Updated the Customer and PaymentMethod models to accommodate the requisite changes
- Updated `TokenizePaymentMethod` usecase to use POST payment-method
- Updated the `TakePayment` usecase