### PR TITLE
[SPRINT-171][MOB-563][MOB-561] Disambiguate MobileReaderConnectionStatus updating case

### DIFF
--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		594466B324A09D4C00C6CFD8 /* TransactionUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597BEA47247FE205009319D6 /* TransactionUpdateDelegate.swift */; };
 		594466B424A09E4200C6CFD8 /* TransactionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59561817248C3FBD00E622B6 /* TransactionUpdate.swift */; };
 		59561818248C3FBD00E622B6 /* TransactionUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59561817248C3FBD00E622B6 /* TransactionUpdate.swift */; };
+		596611A725E6CE8400AEDB2E /* UserNotificationListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596611A625E6CE8400AEDB2E /* UserNotificationListener.swift */; };
+		596611A825E6CE8400AEDB2E /* UserNotificationListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596611A625E6CE8400AEDB2E /* UserNotificationListener.swift */; };
+		596611AB25E6D19200AEDB2E /* UserNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596611A525E6CD7800AEDB2E /* UserNotification.swift */; };
+		596611AD25E6D19300AEDB2E /* UserNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596611A525E6CD7800AEDB2E /* UserNotification.swift */; };
 		5966543C25003B8800A56943 /* TmsStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 5966542125003B8600A56943 /* TmsStatus.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5966543D25003B8800A56943 /* CCParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 5966542225003B8600A56943 /* CCParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5966543E25003B8800A56943 /* UserNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 5966542325003B8600A56943 /* UserNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -216,6 +220,7 @@
 		594466B0249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileReaderConnectionStatus.swift; sourceTree = "<group>"; };
 		59561817248C3FBD00E622B6 /* TransactionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionUpdate.swift; sourceTree = "<group>"; };
 		596611A525E6CD7800AEDB2E /* UserNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotification.swift; sourceTree = "<group>"; };
+		596611A625E6CE8400AEDB2E /* UserNotificationListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationListener.swift; sourceTree = "<group>"; };
 		5966542125003B8600A56943 /* TmsStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TmsStatus.h; sourceTree = "<group>"; };
 		5966542225003B8600A56943 /* CCParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCParameters.h; sourceTree = "<group>"; };
 		5966542325003B8600A56943 /* UserNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserNotification.h; sourceTree = "<group>"; };
@@ -524,6 +529,7 @@
 				D78FA931240EF48B00398D81 /* SignatureProviding.swift */,
 				597BEA47247FE205009319D6 /* TransactionUpdateDelegate.swift */,
 				594466AD249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift */,
+				596611A625E6CE8400AEDB2E /* UserNotificationListener.swift */,
 			);
 			path = Cardpresent;
 			sourceTree = "<group>";
@@ -844,6 +850,7 @@
 				597BEA48247FE205009319D6 /* TransactionUpdateDelegate.swift in Sources */,
 				D73BBCF5244D7F380052B525 /* DisconnectMobileReader.swift in Sources */,
 				D73BBCF2244D697F0052B525 /* GetConnectedMobileReader.swift in Sources */,
+				596611A725E6CE8400AEDB2E /* UserNotificationListener.swift in Sources */,
 				D71B6F91239E971A007FB7C4 /* ChipDnaDriver.swift in Sources */,
 				D765D46F23CC488000656040 /* Merchant.swift in Sources */,
 				D79308BB23D0ADEF0066FCA2 /* InitializeDrivers.swift in Sources */,
@@ -855,6 +862,7 @@
 				D765D47523CC4A1400656040 /* Transaction.swift in Sources */,
 				D7A28D612433E2CA00FC8872 /* TakePayment.swift in Sources */,
 				D79308C723D1045C0066FCA2 /* Omni.swift in Sources */,
+				596611AB25E6D19200AEDB2E /* UserNotification.swift in Sources */,
 				5993C25E2076BD73004DDA9F /* CreditCard.swift in Sources */,
 				D79308BE23D0AF3D0066FCA2 /* TakeMobileReaderPayment.swift in Sources */,
 				594466AB249C5BDC00C6CFD8 /* CancelCurrentTransaction.swift in Sources */,
@@ -911,6 +919,7 @@
 			files = (
 				D765D48823CE422400656040 /* JSONValueTest.swift in Sources */,
 				D760D82A23D884680075057C /* CustomerJson.swift in Sources */,
+				596611A825E6CE8400AEDB2E /* UserNotificationListener.swift in Sources */,
 				D765D4A023CFCA1400656040 /* Amount.swift in Sources */,
 				D783DAC42449F35E007C0A17 /* TakePaymentTests.swift in Sources */,
 				594466AF249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift in Sources */,
@@ -925,6 +934,7 @@
 				D765D47A23CC4B1100656040 /* CustomerRepository.swift in Sources */,
 				D7A28D652436278600FC8872 /* TokenizePaymentMethod.swift in Sources */,
 				D765D47623CC4A1400656040 /* Transaction.swift in Sources */,
+				596611AD25E6D19300AEDB2E /* UserNotification.swift in Sources */,
 				D79308A823D0A9050066FCA2 /* MobileReaderDriver.swift in Sources */,
 				594466B324A09D4C00C6CFD8 /* TransactionUpdateDelegate.swift in Sources */,
 				D7C17B2423E4BA200031D9BB /* TakeMobileReaderPayment.swift in Sources */,

--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		594466AD249E94F800C6CFD8 /* MobileReaderConnectionStatusDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileReaderConnectionStatusDelegate.swift; sourceTree = "<group>"; };
 		594466B0249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileReaderConnectionStatus.swift; sourceTree = "<group>"; };
 		59561817248C3FBD00E622B6 /* TransactionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionUpdate.swift; sourceTree = "<group>"; };
+		596611A525E6CD7800AEDB2E /* UserNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotification.swift; sourceTree = "<group>"; };
 		5966542125003B8600A56943 /* TmsStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TmsStatus.h; sourceTree = "<group>"; };
 		5966542225003B8600A56943 /* CCParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CCParameters.h; sourceTree = "<group>"; };
 		5966542325003B8600A56943 /* UserNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserNotification.h; sourceTree = "<group>"; };
@@ -596,6 +597,7 @@
 				D79308A923D0A9FB0066FCA2 /* TransactionRequest.swift */,
 				D79308AC23D0AA230066FCA2 /* TransactionResult.swift */,
 				59561817248C3FBD00E622B6 /* TransactionUpdate.swift */,
+				596611A525E6CD7800AEDB2E /* UserNotification.swift */,
 				594466B0249E993C00C6CFD8 /* MobileReaderConnectionStatus.swift */,
 			);
 			path = Data;

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCDriver.swift
@@ -177,6 +177,18 @@ class AWCDriver: NSObject, MobileReaderDriver, CBCentralManagerDelegate {
                           signatureProvider: SignatureProviding?,
                           transactionUpdateDelegate: TransactionUpdateDelegate?,
                           completion: @escaping (TransactionResult) -> Void) {
+    performTransaction(with: request,
+                       signatureProvider: signatureProvider,
+                       transactionUpdateDelegate: transactionUpdateDelegate,
+                       userNotificationDelegate: nil,
+                       completion: completion)
+  }
+
+  func performTransaction(with request: TransactionRequest,
+                          signatureProvider: SignatureProviding?,
+                          transactionUpdateDelegate: TransactionUpdateDelegate?,
+                          userNotificationDelegate: UserNotificationDelegate?,
+                          completion: @escaping (TransactionResult) -> Void) {
     // Create AnyPay Transaction
     let transaction = AnyPayTransaction(type: .SALE)
     transaction?.currency = "USD"

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -213,6 +213,18 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
   }
 
   func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, completion: @escaping (TransactionResult) -> Void) {
+    performTransaction(with: request,
+                       signatureProvider: signatureProvider,
+                       transactionUpdateDelegate: transactionUpdateDelegate,
+                       userNotificationDelegate: nil,
+                       completion: completion)
+  }
+
+  func performTransaction(with request: TransactionRequest,
+                          signatureProvider: SignatureProviding?,
+                          transactionUpdateDelegate: TransactionUpdateDelegate?,
+                          userNotificationDelegate: UserNotificationDelegate?,
+                          completion: @escaping (TransactionResult) -> Void) {
     let requestParams = CCParameters(transactionRequest: request)
 
     chipDnaTransactionListener.detachFromChipDna()
@@ -246,7 +258,9 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
       }
     }
 
-    chipDnaTransactionListener.bindToChipDna(signatureProvider: signatureProvider, transactionUpdateDelegate: transactionUpdateDelegate)
+    chipDnaTransactionListener.bindToChipDna(signatureProvider: signatureProvider,
+                                             transactionUpdateDelegate: transactionUpdateDelegate,
+                                             userNotificationDelegate: userNotificationDelegate)
 
     ChipDnaMobile.sharedInstance()?.startTransaction(requestParams)
   }

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaTransactionListener.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaTransactionListener.swift
@@ -22,9 +22,13 @@ class ChipDnaTransactionListener: NSObject {
   /// Gets notified of transaction events
   weak var transactionUpdateDelegate: TransactionUpdateDelegate?
 
+  /// Gets notified of user notification events
+  weak var userNotificationDelegate: UserNotificationDelegate?
+
   /// Makes this listener bind to the transaction events ChipDna emits
   func bindToChipDna(signatureProvider: SignatureProviding? = nil,
-                     transactionUpdateDelegate: TransactionUpdateDelegate? = nil) {
+                     transactionUpdateDelegate: TransactionUpdateDelegate? = nil,
+                     userNotificationDelegate: UserNotificationDelegate? = nil) {
     ChipDnaMobile.addTransactionUpdateTarget(self, action: #selector(onTransactionUpdate(parameters:)))
     ChipDnaMobile.addTransactionFinishedTarget(self, action: #selector(onTransactionFinished(parameters:)))
     ChipDnaMobile.addDeferredAuthorizationTarget(self, action: #selector(onDeferredAuthorization(parameters:)))
@@ -35,6 +39,7 @@ class ChipDnaTransactionListener: NSObject {
     ChipDnaMobile.addIdVerificationTarget(self, action: #selector(onIdVerification(parameters:)))
     ChipDnaMobile.addUserNotificationTarget(self, action: #selector(onUserNotification(parameters:)))
     ChipDnaMobile.addCardApplicationSelectionTarget(self, action: #selector(onApplicationSelection(parameters:)))
+    self.userNotificationDelegate = userNotificationDelegate
     self.transactionUpdateDelegate = transactionUpdateDelegate
     self.signatureProvider = signatureProvider
   }
@@ -64,7 +69,14 @@ class ChipDnaTransactionListener: NSObject {
   }
 
   @objc fileprivate func onUserNotification(parameters: CCParameters) {
+    guard
+      let delegate = userNotificationDelegate,
+      let userNotificationString = parameters.value(forKey: "USER_NOTIFICATION") ?? nil,
+      let update = UserNotification(chipDnaUserNotification: userNotificationString) else {
+      return
+    }
 
+    delegate.onUserNotification(userNotification: update)
   }
 
   @objc fileprivate func onTransactionFinished(parameters: CCParameters) {

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -64,6 +64,42 @@ extension TransactionUpdate {
   }
 }
 
+extension UserNotification {
+
+  /// Makes an Omni TransactionUpdate from a ChipDna TransactionUpdate string
+  init?(chipDnaUserNotification: String) {
+    switch chipDnaUserNotification {
+
+    case UserNotificationTryCardAgain:
+      self = UserNotification.TryCardAgain
+
+    case UserNotificationChipReadErrorApplicationNotSupportedPleaseRetry:
+      self = UserNotification.ChipReadErrorApplicationNotSupportedPleaseRetry
+
+    case UserNotificationICCFallforward:
+      self = UserNotification.FallforwardInsertCard
+
+    case UserNotificationICCMSRFallforward:
+      self = UserNotification.FallforwardInsertSwipeCard
+
+    case UserNotificationMSRFallback:
+      self = UserNotification.FallbackSwipeCard
+
+    case UserNotificationMSRFallforward:
+      self = UserNotification.FallforwardSwipeCard
+
+    case UserNotificationPresentOnlyOneCard:
+      self = UserNotification.PresentOneCardOnly
+
+    case UserNotificationReferToDevice:
+      self = UserNotification.ReferToDevice
+
+    default:
+      return nil
+    }
+  }
+}
+
 extension MobileReaderConnectionStatus {
 
   /// Initializes a `MobileReaderConnectionStatus` object from the given ChipDnaConfigurationUpdate

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -87,11 +87,14 @@ extension MobileReaderConnectionStatus {
   /// is obtained by grabbing the value of `CCParamConfigurationUpdate`
   init?(chipDnaConfigurationUpdate configUpdate: String) {
     switch configUpdate {
-    case CCValueConnecting:
+    case CCValueRegistering, CCValueConnecting:
       self = .connecting
 
-    case CCValueRegistering, CCValuePerformingTmsUpdate, CCValueUpdatingPinPadFirmware:
-      self = .updating
+    case CCValuePerformingTmsUpdate:
+      self = .updating_configuration
+
+    case CCValueUpdatingPinPadFirmware:
+      self = .updating_firmware
 
     case CCValueRebootingPinPad:
       self = .rebooting

--- a/fattmerchant-ios-sdk/Cardpresent/Data/MobileReaderConnectionStatus.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/MobileReaderConnectionStatus.swift
@@ -20,9 +20,12 @@ public enum MobileReaderConnectionStatus: String {
   case disconnected
 
   /// The reader is performing an update
+  case updating_configuration
+
+  /// The reader is performing an update on the firmware
   ///
-  /// - Note: This might be a long-running operation
-  case updating
+  /// - Note: This is a long-running operation
+  case updating_firmware
 
   /// The reader is performing a reboot
   case rebooting

--- a/fattmerchant-ios-sdk/Cardpresent/Data/UserNotification.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/UserNotification.swift
@@ -1,0 +1,55 @@
+//
+//  UserNotification.swift
+//  Fattmerchant
+//
+//  Created by Tulio Troncoso on 2/24/21.
+//  Copyright © 2020 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+/// Represents a user notification
+///
+/// This object will provide information about events that prompt the user.
+public struct UserNotification {
+
+  /// Describes what the transaction status is
+  ///
+  /// Example: "Prompt User Fallback Swipe Card"
+  public let value: String
+
+  /// A message that you can show to the end user
+  ///
+  /// Example: "Please swipe your card."
+  public let userFriendlyMessage: String?
+
+  public init(_ value: String, _ userFriendlyMessage: String? = nil) {
+    self.value = value
+    self.userFriendlyMessage = userFriendlyMessage
+  }
+  /// Indicates referral to the device
+  public static let ReferToDevice = UserNotification("Prompt User Refer To Device", "Please check your device.")
+
+  /// Indicates there has been an issue with the ICC chip and the user should retry
+  public static let ChipReadErrorApplicationNotSupportedPleaseRetry = UserNotification("Prompt User Error Application Not Supported",
+          "There was an error with processing the chip card. Please try again.")
+
+  /// Indicates that only one card should be presented
+  public static let PresentOneCardOnly = UserNotification("Prompt User Present One Card Only", "Please only present one card.")
+
+  /// Indicates that fallback to Swipe has occurred
+  public static let FallbackSwipeCard = UserNotification("Prompt User Fallback Swipe Card", "Please swipe your card.")
+
+  /// Indicates that fallforward to Swipe has occurred
+  public static let FallforwardSwipeCard = UserNotification("Prompt User Fallforward Swipe Card", "Please swipe your card.")
+
+  /// Indicates that fallforward to Insert has occurred
+  public static let FallforwardInsertCard = UserNotification("Prompt User Fallforward Insert Card", "Please insert your card.")
+
+  /// Indicates that fallforward to Insert/Swipe has occurred
+  public static let FallforwardInsertSwipeCard = UserNotification("Prompt User Fallforward Insert Swipe Card", "Please insert or swipe your card.")
+
+  /// Indicates that the card should be tried again
+  public static let TryCardAgain = UserNotification( "Prompt User Try Card Again","Please try your card again.")
+
+}

--- a/fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift
@@ -62,6 +62,8 @@ protocol MobileReaderDriver {
 
   func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, completion: @escaping (TransactionResult) -> Void)
 
+  func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, userNotificationDelegate: UserNotificationDelegate?, completion: @escaping (TransactionResult) -> Void)
+
   func cancelCurrentTransaction(completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void)
 
   func disconnect(reader: MobileReader, completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void)
@@ -69,4 +71,15 @@ protocol MobileReaderDriver {
   func refund(transaction: Transaction, refundAmount: Amount?, completion: @escaping (TransactionResult) -> Void, error: @escaping (OmniException) -> Void)
 
   func getConnectedReader(completion: (MobileReader?) -> Void, error: @escaping (OmniException) -> Void)
+}
+
+extension MobileReaderDriver {
+  func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, completion: @escaping (TransactionResult) -> Void) {
+    performTransaction(with: request,
+                       signatureProvider: signatureProvider,
+                       transactionUpdateDelegate: transactionUpdateDelegate,
+                       userNotificationDelegate: nil,
+                       completion: completion)
+  }
+
 }

--- a/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
@@ -72,6 +72,10 @@ class MockDriver: MobileReaderDriver {
     completion(reader)
   }
 
+  func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, userNotificationDelegate: UserNotificationDelegate?, completion: @escaping (TransactionResult) -> Void) {
+    performTransaction(with: request, signatureProvider: signatureProvider, transactionUpdateDelegate: transactionUpdateDelegate, completion: completion)
+  }
+
   func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, completion: @escaping (TransactionResult) -> Void) {
     let transactionResult = TransactionResult(
       request: request,

--- a/fattmerchant-ios-sdk/Cardpresent/Omni.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Omni.swift
@@ -93,6 +93,9 @@ public class Omni: NSObject {
   /// Receives notifications about transaction events such as when a card is swiped
   public weak var transactionUpdateDelegate: TransactionUpdateDelegate?
 
+  /// Receives notifications about user-facing transaction events such as when a user swipes a chip card
+  public weak var userNotificationDelegate: UserNotificationDelegate?
+
   /// Receives notifications about reader connection events
   public weak var mobileReaderConnectionUpdateDelegate: MobileReaderConnectionStatusDelegate?
 
@@ -235,7 +238,7 @@ public class Omni: NSObject {
       return error(OmniGeneralException.uninitialized)
     }
 
-    let job = TakeMobileReaderPayment(
+    let job: TakeMobileReaderPayment = TakeMobileReaderPayment(
       mobileReaderDriverRepository: mobileReaderDriverRepository,
       invoiceRepository: invoiceRepository,
       customerRepository: customerRepository,
@@ -243,7 +246,8 @@ public class Omni: NSObject {
       transactionRepository: transactionRepository,
       request: request,
       signatureProvider: signatureProvider,
-      transactionUpdateDelegate: transactionUpdateDelegate
+      transactionUpdateDelegate: transactionUpdateDelegate,
+      userNotificationDelegate: userNotificationDelegate
     )
 
     job.start(completion: completion, failure: error)

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -61,6 +61,7 @@ class TakeMobileReaderPayment {
   var request: TransactionRequest
   var signatureProvider: SignatureProviding?
   weak var transactionUpdateDelegate: TransactionUpdateDelegate?
+  weak var userNotificationDelegate: UserNotificationDelegate?
 
   init(
     mobileReaderDriverRepository: MobileReaderDriverRepository,
@@ -70,7 +71,8 @@ class TakeMobileReaderPayment {
     transactionRepository: TransactionRepository,
     request: TransactionRequest,
     signatureProvider: SignatureProviding?,
-    transactionUpdateDelegate: TransactionUpdateDelegate?) {
+    transactionUpdateDelegate: TransactionUpdateDelegate?,
+    userNotificationDelegate: UserNotificationDelegate?) {
 
     self.mobileReaderDriverRepository = mobileReaderDriverRepository
     self.invoiceRepository = invoiceRepository
@@ -80,6 +82,7 @@ class TakeMobileReaderPayment {
     self.request = request
     self.signatureProvider = signatureProvider
     self.transactionUpdateDelegate = transactionUpdateDelegate
+    self.userNotificationDelegate = userNotificationDelegate
   }
 
   func start(completion: @escaping (Transaction) -> Void, failure: @escaping (OmniException) -> Void) {
@@ -88,6 +91,7 @@ class TakeMobileReaderPayment {
         self.takeMobileReaderPayment(with: driver,
                                      signatureProvider: self.signatureProvider,
                                      transactionUpdateDelegate: self.transactionUpdateDelegate,
+                                     userNotificationDelegate: self.userNotificationDelegate,
                                      failure) { (mobileReaderPaymentResult) in
                                       self.createCustomer(mobileReaderPaymentResult, failure) { (createdCustomer) in
                                         self.createPaymentMethod(for: createdCustomer, mobileReaderPaymentResult, failure) { (createdPaymentMethod) in
@@ -357,11 +361,13 @@ class TakeMobileReaderPayment {
   fileprivate func takeMobileReaderPayment(with driver: MobileReaderDriver,
                                            signatureProvider: SignatureProviding?,
                                            transactionUpdateDelegate: TransactionUpdateDelegate?,
+                                           userNotificationDelegate: UserNotificationDelegate?,
                                            _ failure: (OmniException) -> Void,
                                            _ completion: @escaping (TransactionResult) -> Void) {
     driver.performTransaction(with: self.request,
                               signatureProvider: signatureProvider,
                               transactionUpdateDelegate: transactionUpdateDelegate,
+                              userNotificationDelegate: userNotificationDelegate,
                               completion: completion)
   }
 

--- a/fattmerchant-ios-sdk/Cardpresent/UserNotificationListener.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/UserNotificationListener.swift
@@ -1,0 +1,18 @@
+//
+//  UserNotificationListener.swift
+//  fattmerchant-ios-sdk
+//
+//  Created by Tulio Troncoso on 2/24/21.
+//  Copyright © 2021 Fattmerchant. All rights reserved.
+//
+
+import Foundation
+
+/// Gets notified of all messages that need to be displayed to a user
+///
+/// For example, "Please insert/swipe your card"
+public protocol UserNotificationDelegate: class {
+
+  /// Called when a prompt is required to be shown to a customer and returns a UserNotification
+  func onUserNotification(userNotification: UserNotification)
+}


### PR DESCRIPTION
## **[Ticket MOB-563](https://fattmerchant.atlassian.net/browse/MOB-563)**
## **[Ticket MOB-561](https://fattmerchant.atlassian.net/browse/MOB-561)**

> **iOS | NMI bbPOS | Getting latest settings**

## What did I do?

* Turned updating into updating_firmware and updating_configuration
* Added the UserNotification listener

![IMG_7BAA453444A2-1](https://user-images.githubusercontent.com/5385681/109061198-5a883980-76b4-11eb-8078-aa385c761626.jpeg)

---

## PR notes contain:

* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:

* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
