### PR TITLE
[SPRINT-172][MOB-335] ApplePay customer name

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
@@ -77,7 +77,8 @@ extension TransactionType {
 }
 
 extension TransactionResult {
-  init(_ anyPayTransaction: AnyPayTransaction) {
+  convenience init(_ anyPayTransaction: AnyPayTransaction) {
+    self.init()
     if anyPayTransaction.status == .DECLINED {
       // Add the responseText, since this usually contains info about why the transaction was declined
       if let responseText = anyPayTransaction.responseText {

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
@@ -124,7 +124,7 @@ extension TransactionResult {
     self.success = anyPayTransaction.status == .APPROVED
     self.transactionType = TransactionType(anyPayTransaction.transactionType).rawValue
 
-    self.isFromMobileDevice = false
+    self.transactionSource = nil
   }
 }
 

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
@@ -123,6 +123,8 @@ extension TransactionResult {
     }
     self.success = anyPayTransaction.status == .APPROVED
     self.transactionType = TransactionType(anyPayTransaction.transactionType).rawValue
+
+    self.isFromMobileDevice = false
   }
 }
 

--- a/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/AnywhereCommerce/AWCUtils.swift
@@ -77,8 +77,7 @@ extension TransactionType {
 }
 
 extension TransactionResult {
-  convenience init(_ anyPayTransaction: AnyPayTransaction) {
-    self.init()
+  init(_ anyPayTransaction: AnyPayTransaction) {
     if anyPayTransaction.status == .DECLINED {
       // Add the responseText, since this usually contains info about why the transaction was declined
       if let responseText = anyPayTransaction.responseText {

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -327,6 +327,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
       transactionResult.success = true
       transactionResult.transactionType = "refund"
       transactionResult.amount = refundAmount
+      transactionResult.isFromMobileDevice = result[CCParamPar] != nil
       completion(transactionResult)
     }
   }

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -232,6 +232,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
     chipDnaTransactionListener.onFinished = { result in
 
       let success = result[CCParamTransactionResult] == CCValueApproved
+      let receiptData = ChipDnaMobileSerializer.deserializeReceiptData(result[CCParamReceiptData])
 
       var transactionResult = TransactionResult()
       transactionResult.source = Self.source
@@ -245,7 +246,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
       transactionResult.userReference = result[CCParamUserReference]
       transactionResult.localId = result[CCParamCardEaseReference]
       transactionResult.externalId = result[CCParamTransactionId]
-      transactionResult.isFromMobileDevice = result[CCParamPar] != nil
+      transactionResult.transactionSource = receiptData?["TRANSACTION_SOURCE"]?.value
 
       if let token = result[CCParamCustomerVaultId] {
         transactionResult.paymentToken = "nmi_\(token)"
@@ -318,6 +319,8 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
       return
     }
 
+    let receiptData = ChipDnaMobileSerializer.deserializeReceiptData(result[CCParamReceiptData])
+
     // Check status
     if result[CCParamErrors] != nil {
       error(RefundException.errorRefunding(details: "Error while performing refund"))
@@ -327,7 +330,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
       transactionResult.success = true
       transactionResult.transactionType = "refund"
       transactionResult.amount = refundAmount
-      transactionResult.isFromMobileDevice = result[CCParamPar] != nil
+      transactionResult.transactionSource = receiptData?["TRANSACTION_SOURCE"]?.value
       completion(transactionResult)
     }
   }

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -245,6 +245,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
       transactionResult.userReference = result[CCParamUserReference]
       transactionResult.localId = result[CCParamCardEaseReference]
       transactionResult.externalId = result[CCParamTransactionId]
+      transactionResult.isFromMobileDevice = result[CCParamPar] != nil
 
       if let token = result[CCParamCustomerVaultId] {
         transactionResult.paymentToken = "nmi_\(token)"

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -233,7 +233,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
 
       let success = result[CCParamTransactionResult] == CCValueApproved
 
-      let transactionResult = TransactionResult()
+      var transactionResult = TransactionResult()
       transactionResult.source = Self.source
       transactionResult.request = request
       transactionResult.success = success
@@ -322,7 +322,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
     if result[CCParamErrors] != nil {
       error(RefundException.errorRefunding(details: "Error while performing refund"))
     } else {
-      let transactionResult = TransactionResult()
+      var transactionResult = TransactionResult()
       transactionResult.source = Self.source
       transactionResult.success = true
       transactionResult.transactionType = "refund"

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaDriver.swift
@@ -233,7 +233,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
 
       let success = result[CCParamTransactionResult] == CCValueApproved
 
-      var transactionResult = TransactionResult()
+      let transactionResult = TransactionResult()
       transactionResult.source = Self.source
       transactionResult.request = request
       transactionResult.success = success
@@ -322,7 +322,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver {
     if result[CCParamErrors] != nil {
       error(RefundException.errorRefunding(details: "Error while performing refund"))
     } else {
-      var transactionResult = TransactionResult()
+      let transactionResult = TransactionResult()
       transactionResult.source = Self.source
       transactionResult.success = true
       transactionResult.transactionType = "refund"

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// This object contains necessary data about the transaction that occured, such as how much money was
 /// collected and details about the payment method used
-struct TransactionResult {
+class TransactionResult {
 
   var request: TransactionRequest?
 
@@ -68,7 +68,7 @@ struct TransactionResult {
   var gatewayResponse: String?
 
   /// Is this transaction from a mobile device?
-  var isFromMobileDevice: Bool
+  var isFromMobileDevice: Bool?
 
   /// The token that represents this payment method
   internal var paymentToken: String?

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// This object contains necessary data about the transaction that occured, such as how much money was
 /// collected and details about the payment method used
-class TransactionResult {
+struct TransactionResult {
 
   var request: TransactionRequest?
 

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
@@ -42,6 +42,9 @@ struct TransactionResult {
   /** Sale, Refund, etc */
   var transactionType: String?
 
+  /** Contactless, etc. */
+  var transactionSource: String?
+
   /** Amount of money that was exchanged */
   var amount: Amount?
 
@@ -66,9 +69,6 @@ struct TransactionResult {
 
   /// The gateway response in its entirety
   var gatewayResponse: String?
-
-  /// Is this transaction from a mobile device?
-  var isFromMobileDevice: Bool?
 
   /// The token that represents this payment method
   internal var paymentToken: String?

--- a/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/TransactionResult.swift
@@ -67,6 +67,9 @@ struct TransactionResult {
   /// The gateway response in its entirety
   var gatewayResponse: String?
 
+  /// Is this transaction from a mobile device?
+  var isFromMobileDevice: Bool
+
   /// The token that represents this payment method
   internal var paymentToken: String?
 

--- a/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
@@ -112,7 +112,7 @@ class MockDriver: MobileReaderDriver {
     transactionResult.amount = Amount(cents: 5)
     transactionResult.cardType = "visa"
     transactionResult.userReference = "cdm-123123"
-    transactionResult.isFromMobileDevice = false
+    transactionResult.transactionSource = nil
 
     completion(transactionResult)
   }
@@ -129,7 +129,7 @@ class MockDriver: MobileReaderDriver {
     transactionResult.amount = Amount(cents: 5)
     transactionResult.cardType = "visa"
     transactionResult.userReference = "cdm-123123"
-    transactionResult.isFromMobileDevice = false
+    transactionResult.transactionSource = nil
 
     completion(transactionResult)
   }

--- a/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
@@ -77,7 +77,7 @@ class MockDriver: MobileReaderDriver {
   }
 
   func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, completion: @escaping (TransactionResult) -> Void) {
-    let transactionResult = TransactionResult()
+    var transactionResult = TransactionResult()
     transactionResult.request = request
     transactionResult.success = true
     transactionResult.maskedPan = "411111111234"
@@ -101,7 +101,7 @@ class MockDriver: MobileReaderDriver {
   }
 
   func refund(transaction: Transaction, refundAmount: Amount?, completion: @escaping (TransactionResult) -> Void, error: @escaping (OmniException) -> Void) {
-    let transactionResult = TransactionResult()
+    var transactionResult = TransactionResult()
     transactionResult.request = nil
     transactionResult.success = true
     transactionResult.maskedPan = "411111111234"
@@ -118,7 +118,7 @@ class MockDriver: MobileReaderDriver {
   }
 
   func refund(transaction: Transaction, completion: @escaping (TransactionResult) -> Void) {
-    let transactionResult = TransactionResult()
+    var transactionResult = TransactionResult()
     transactionResult.request = nil
     transactionResult.success = true
     transactionResult.maskedPan = "411111111234"

--- a/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
@@ -77,19 +77,17 @@ class MockDriver: MobileReaderDriver {
   }
 
   func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, completion: @escaping (TransactionResult) -> Void) {
-    let transactionResult = TransactionResult(
-      request: request,
-      success: true,
-      maskedPan: "411111111234",
-      cardHolderFirstName: "William",
-      cardHolderLastName: "Holder",
-      authCode: "abc123",
-      transactionType: "charge",
-      amount: request.amount,
-      cardType: "visa",
-      userReference: "cdm-123123",
-      isFromMobileDevice: false
-    )
+    let transactionResult = TransactionResult()
+    transactionResult.request = request
+    transactionResult.success = true
+    transactionResult.maskedPan = "411111111234"
+    transactionResult.cardHolderFirstName = "William"
+    transactionResult.cardHolderLastName = "Holder"
+    transactionResult.authCode = "abc123"
+    transactionResult.transactionType = "charge"
+    transactionResult.amount = request.amount
+    transactionResult.cardType = "visa"
+    transactionResult.userReference = "cdm-123123"
 
     completion(transactionResult)
   }
@@ -103,37 +101,35 @@ class MockDriver: MobileReaderDriver {
   }
 
   func refund(transaction: Transaction, refundAmount: Amount?, completion: @escaping (TransactionResult) -> Void, error: @escaping (OmniException) -> Void) {
-    let transactionResult = TransactionResult(
-      request: nil,
-      success: true,
-      maskedPan: "411111111234",
-      cardHolderFirstName: "William",
-      cardHolderLastName: "Holder",
-      authCode: "def456",
-      transactionType: "refund",
-      amount: Amount(cents: 5),
-      cardType: "visa",
-      userReference: "cdm-123123",
-      isFromMobileDevice: false
-    )
+    let transactionResult = TransactionResult()
+    transactionResult.request = nil
+    transactionResult.success = true
+    transactionResult.maskedPan = "411111111234"
+    transactionResult.cardHolderFirstName = "William"
+    transactionResult.cardHolderLastName = "Holder"
+    transactionResult.authCode = "def456"
+    transactionResult.transactionType = "refund"
+    transactionResult.amount = Amount(cents: 5)
+    transactionResult.cardType = "visa"
+    transactionResult.userReference = "cdm-123123"
+    transactionResult.isFromMobileDevice = false
 
     completion(transactionResult)
   }
 
   func refund(transaction: Transaction, completion: @escaping (TransactionResult) -> Void) {
-    let transactionResult = TransactionResult(
-      request: nil,
-      success: true,
-      maskedPan: "411111111234",
-      cardHolderFirstName: "William",
-      cardHolderLastName: "Holder",
-      authCode: "def456",
-      transactionType: "refund",
-      amount: Amount(cents: 5),
-      cardType: "visa",
-      userReference: "cdm-123123",
-      isFromMobileDevice: false
-    )
+    let transactionResult = TransactionResult()
+    transactionResult.request = nil
+    transactionResult.success = true
+    transactionResult.maskedPan = "411111111234"
+    transactionResult.cardHolderFirstName = "William"
+    transactionResult.cardHolderLastName = "Holder"
+    transactionResult.authCode = "def456"
+    transactionResult.transactionType = "refund"
+    transactionResult.amount = Amount(cents: 5)
+    transactionResult.cardType = "visa"
+    transactionResult.userReference = "cdm-123123"
+    transactionResult.isFromMobileDevice = false
 
     completion(transactionResult)
   }

--- a/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Mock/MockDriver.swift
@@ -87,7 +87,8 @@ class MockDriver: MobileReaderDriver {
       transactionType: "charge",
       amount: request.amount,
       cardType: "visa",
-      userReference: "cdm-123123"
+      userReference: "cdm-123123",
+      isFromMobileDevice: false
     )
 
     completion(transactionResult)
@@ -112,7 +113,8 @@ class MockDriver: MobileReaderDriver {
       transactionType: "refund",
       amount: Amount(cents: 5),
       cardType: "visa",
-      userReference: "cdm-123123"
+      userReference: "cdm-123123",
+      isFromMobileDevice: false
     )
 
     completion(transactionResult)
@@ -129,7 +131,8 @@ class MockDriver: MobileReaderDriver {
       transactionType: "refund",
       amount: Amount(cents: 5),
       cardType: "visa",
-      userReference: "cdm-123123"
+      userReference: "cdm-123123",
+      isFromMobileDevice: false
     )
 
     completion(transactionResult)

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -353,8 +353,20 @@ class TakeMobileReaderPayment {
 
   fileprivate func createCustomer(_ transactionResult: TransactionResult, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Customer) -> Void) {
     let customerToCreate = Customer()
-    customerToCreate.firstname = transactionResult.cardHolderFirstName ?? "SWIPE"
-    customerToCreate.lastname = transactionResult.cardHolderLastName ?? "CUSTOMER"
+
+    if let mobileDeviceCustomer = transactionResult.isFromMobileDevice {
+      if(mobileDeviceCustomer) {
+        customerToCreate.firstname = "Mobile Device"
+        customerToCreate.lastname = "Customer"
+      } else {
+        customerToCreate.firstname = transactionResult.cardHolderFirstName ?? "SWIPE"
+        customerToCreate.lastname = transactionResult.cardHolderLastName ?? "CUSTOMER"
+      }
+    } else {
+      customerToCreate.firstname = transactionResult.cardHolderFirstName ?? "SWIPE"
+      customerToCreate.lastname = transactionResult.cardHolderLastName ?? "CUSTOMER"
+    }
+
     customerRepository.create(model: customerToCreate, completion: completion, error: failure)
   }
 

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -354,9 +354,9 @@ class TakeMobileReaderPayment {
   fileprivate func createCustomer(_ transactionResult: TransactionResult, _ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Customer) -> Void) {
     let customerToCreate = Customer()
 
-    if let mobileDeviceCustomer = transactionResult.isFromMobileDevice {
-      if(mobileDeviceCustomer) {
-        customerToCreate.firstname = "Mobile Device"
+    if let transactionSource = transactionResult.transactionSource {
+      if transactionSource.caseInsensitiveCompare("contactless") == .orderedSame {
+        customerToCreate.firstname = "Contactless"
         customerToCreate.lastname = "Customer"
       } else {
         customerToCreate.firstname = transactionResult.cardHolderFirstName ?? "SWIPE"


### PR DESCRIPTION
## **[Ticket MOB-335](https://fattmerchant.atlassian.net/browse/MOB-335)**

> **iOS SDK | ChipDNA | Customer name for Apple Pay transaction is "SWIPE CUSTOMER"**

## What did I do?

* Added new field to `TransactionResult` called `isFromMobileDevice`
* After mobile reader payment is completed check to see if there is a CCParamPar value which determines if the transaction has a device PAN.
* When creating a new customer check to see if the transaction `isFromMobileDevice` and set the name to "Mobile Device Customer"

---

## PR notes contain:

* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:

* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
