### PR TITLE
[SPRINT-177][MOB-706] Fix meta field of invoice

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -251,6 +251,9 @@ class TakeMobileReaderPayment {
 
     if let subtotal = self.request.subtotal {
       dict["subtotal"] = JSONValue(subtotal)
+    } else {
+      // If the user does not specify a subtotal, we a
+      dict["subtotal"] = JSONValue(request.amount.dollars())
     }
 
     if let tax = self.request.tax {


### PR DESCRIPTION
## **[Ticket MOB-706](https://fattmerchant.atlassian.net/browse/MOB-706)**

> **iOS SDK 2.0.0 | Getting "Error taking mobile reader payment. Invoice id is required" when taking a payment without an invoice id**

## What did I do?

* When there is no subtotal in the transaction request, put the total in the subtotal field. The subtotal field is required and when it's blank the API does not actually create the invoice

---

## PR notes contain:

* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:

* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
