### PR TITLE
[MOB-683] Check for blank invoice ids before taking mobile reader payment

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -12,6 +12,7 @@ enum TakeMobileReaderPaymentException: OmniException {
   case mobileReaderNotFound
   case mobileReaderNotReady
   case invoiceNotFound
+  case invoiceIdCannotBeBlank
   case couldNotCreateInvoice(detail: String?)
   case couldNotCreateCustomer(detail: String?)
   case couldNotCreatePaymentMethod(detail: String?)
@@ -45,6 +46,9 @@ enum TakeMobileReaderPaymentException: OmniException {
 
     case .couldNotCreateTransaction(let d):
       return d ?? "Could not create transaction"
+
+    case .invoiceIdCannotBeBlank:
+      return "Could not create invoice"
     }
   }
 
@@ -87,7 +91,6 @@ class TakeMobileReaderPayment {
     availableMobileReaderDriver(mobileReaderDriverRepository, failure) { driver in
 
       self.getOrCreateInvoice(failure) { (createdInvoice) in
-
         self.takeMobileReaderPayment(with: driver,
                                      signatureProvider: self.signatureProvider,
                                      transactionUpdateDelegate: self.transactionUpdateDelegate,
@@ -295,6 +298,7 @@ class TakeMobileReaderPayment {
                                            transactionUpdateDelegate: TransactionUpdateDelegate?,
                                            _ failure: (OmniException) -> Void,
                                            _ completion: @escaping (TransactionResult) -> Void) {
+    print("Performing transaction")
     driver.performTransaction(with: self.request, signatureProvider: signatureProvider, transactionUpdateDelegate: transactionUpdateDelegate, completion: completion)
   }
 
@@ -302,6 +306,10 @@ class TakeMobileReaderPayment {
   internal func getOrCreateInvoice(_ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Invoice) -> Void) {
     // If an invoiceId was given in the transaction request, we should verify that an invoice with that id exists
     if let invoiceId = request.invoiceId {
+      guard !invoiceId.isEmpty else {
+        failure(TakeMobileReaderPaymentException.invoiceIdCannotBeBlank)
+        return
+      }
       invoiceRepository.getById(id: invoiceId, completion: completion) { (error) in
         failure(TakeMobileReaderPaymentException.invoiceNotFound)
       }
@@ -319,7 +327,12 @@ class TakeMobileReaderPayment {
       }
 
       invoiceToCreate.meta = invoiceMetaJson
-      invoiceRepository.create(model: invoiceToCreate, completion: completion, error: failure)
+      invoiceRepository.create(model: invoiceToCreate, completion: { createdInvoice in
+        guard createdInvoice.id == "" else {
+          return failure(TakeMobileReaderPaymentException.couldNotCreateInvoice(detail: nil))
+        }
+        completion(createdInvoice)
+      }, error: failure)
     }
   }
 


### PR DESCRIPTION
## **[Ticket MOB-683](https://fattmerchant.atlassian.net/browse/MOB-683)**

> **[EFS][EPS][NMI][AWC][BBPOS] Transactions not getting created initially when ran on mobile reader**

## What did I do?

* Check for invoiceId that are empty strings before creating the transaction

---

## PR notes contain:

* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:

* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I created `data-testid` attributes for any new UI
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
