### PR TITLE
[SPRINT-179][MOB-725] Confirm transaction after creating omni records

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -142,7 +142,6 @@ extension CCParameters {
     self[CCParamCurrency] = "USD"
     self[CCParamUserReference] = generateChipDnaTransactionUserReference()
     self[CCParamPaymentMethod] = CCValueCard
-//    self[CCParamAutoConfirm] = CCValueTrue
     self[CCParamTransactionType] = CCValueSale
 
     if transactionRequest.tokenize {

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -142,7 +142,7 @@ extension CCParameters {
     self[CCParamCurrency] = "USD"
     self[CCParamUserReference] = generateChipDnaTransactionUserReference()
     self[CCParamPaymentMethod] = CCValueCard
-    self[CCParamAutoConfirm] = CCValueTrue
+//    self[CCParamAutoConfirm] = CCValueTrue
     self[CCParamTransactionType] = CCValueSale
 
     if transactionRequest.tokenize {

--- a/fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift
@@ -62,11 +62,27 @@ protocol MobileReaderDriver {
 
   func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, completion: @escaping (TransactionResult) -> Void)
 
+  func capture(transaction: Transaction, completion: @escaping (Bool) -> Void)
+
   func cancelCurrentTransaction(completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void)
 
   func disconnect(reader: MobileReader, completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void)
 
   func refund(transaction: Transaction, refundAmount: Amount?, completion: @escaping (TransactionResult) -> Void, error: @escaping (OmniException) -> Void)
 
+  func void(transactionResult: TransactionResult, completion: @escaping (Bool) -> Void)
+
   func getConnectedReader(completion: (MobileReader?) -> Void, error: @escaping (OmniException) -> Void)
+}
+
+extension MobileReaderDriver {
+  func capture(transaction: Transaction, completion: @escaping (Bool) -> Void) {
+    print("MobileReaderDriver#capture not implemented")
+    completion(true)
+  }
+
+  func void(transactionResult: TransactionResult, completion: @escaping (Bool) -> Void) {
+    print("MobileReaderDriver#void not implemented")
+    completion(true)
+  }
 }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -135,13 +135,13 @@ class TakeMobileReaderPayment {
                       failedTransaction.message = "Error capturing the transaction"
 
                       // Fail the transaction in omni
-                      self.transactionRepository.update(model: failedTransaction, id: transactionId) { (updatedTransaction) in
+                      self.transactionRepository.update(model: failedTransaction, id: transactionId, completion: { _ in
                         voidAndFail(TakeMobileReaderPaymentException.couldNotCaptureTransaction)
                         return
-                      } error: { (error) in
+                      }, error: { _ in
                         voidAndFail(TakeMobileReaderPaymentException.couldNotCaptureTransaction)
                         return
-                      }
+                      })
                     }
                   }
                 }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -366,7 +366,7 @@ class TakeMobileReaderPayment {
 
       invoiceToCreate.meta = invoiceMetaJson
       invoiceRepository.create(model: invoiceToCreate, completion: { createdInvoice in
-        guard createdInvoice.id == "" else {
+        guard createdInvoice.id?.isEmpty != true else {
           return failure(TakeMobileReaderPaymentException.couldNotCreateInvoice(detail: nil))
         }
         completion(createdInvoice)

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -102,6 +102,10 @@ class TakeMobileReaderPayment {
 
           // This is a callback that voids the transaction and calls the fail block
           let voidAndFail: (OmniException) -> Void = { exception in
+
+            // By the time this is invoked, the NMI transaction went through fine but something happened while doing
+            // one of the calls to Omni. Since the transaction is pending confirmation, then we need to void it *before*
+            // invoking the failure block. That way the customer gets their money back
             driver.void(transactionResult: mobileReaderPaymentResult) { _ in
               failure(exception)
             }


### PR DESCRIPTION
## **[Ticket MOB-725](https://fattmerchant.atlassian.net/browse/MOB-725)**

> **iOS SDK | Only confirm payment once auth and omni requests are successful**

## What did I do?

* Added a `capture` and `void` method to `MobileReaderDriver`. These methods are  🔑  to the implementation of the new payment flow
* Added default implementations of capture and void because AWC doesn't support it yet, but the payments should still go through fine. AWC should just bypass the capture
* Changed the order of operations of `TakeMobileReaderPayment`. It will now do an auth in the mobile reader step, create all the records in Omni, and then capture the amount it authed

---

## PR notes contain:

* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:

* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I created `data-testid` attributes for any new UI
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
