### PR TITLE
Release/1.4.5

### DIFF
--- a/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
+++ b/fattmerchant-ios-sdk.xcodeproj/project.pbxproj
@@ -1080,7 +1080,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1101,7 +1101,7 @@
 					"$(PROJECT_DIR)/fattmerchant-ios-sdk/Cardpresent/ChipDnaMobile",
 					"$(PROJECT_DIR)/fattmerchant-ios-sdk/Cardpresent/ChipDnaMobile/SQLCipher",
 				);
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-lz";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fattmerchant.fattmerchant-ios-sdk";
@@ -1117,7 +1117,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1138,7 +1138,7 @@
 					"$(PROJECT_DIR)/fattmerchant-ios-sdk/Cardpresent/ChipDnaMobile",
 					"$(PROJECT_DIR)/fattmerchant-ios-sdk/Cardpresent/ChipDnaMobile/SQLCipher",
 				);
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-lz";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fattmerchant.fattmerchant-ios-sdk";

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -142,7 +142,6 @@ extension CCParameters {
     self[CCParamCurrency] = "USD"
     self[CCParamUserReference] = generateChipDnaTransactionUserReference()
     self[CCParamPaymentMethod] = CCValueCard
-//    self[CCParamAutoConfirm] = CCValueTrue
     self[CCParamTransactionType] = CCValueSale
 
     if transactionRequest.tokenize {

--- a/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/ChipDna/ChipDnaUtils.swift
@@ -142,7 +142,7 @@ extension CCParameters {
     self[CCParamCurrency] = "USD"
     self[CCParamUserReference] = generateChipDnaTransactionUserReference()
     self[CCParamPaymentMethod] = CCValueCard
-    self[CCParamAutoConfirm] = CCValueTrue
+//    self[CCParamAutoConfirm] = CCValueTrue
     self[CCParamTransactionType] = CCValueSale
 
     if transactionRequest.tokenize {

--- a/fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/MobileReaderDriver.swift
@@ -62,11 +62,27 @@ protocol MobileReaderDriver {
 
   func performTransaction(with request: TransactionRequest, signatureProvider: SignatureProviding?, transactionUpdateDelegate: TransactionUpdateDelegate?, completion: @escaping (TransactionResult) -> Void)
 
+  func capture(transaction: Transaction, completion: @escaping (Bool) -> Void)
+
   func cancelCurrentTransaction(completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void)
 
   func disconnect(reader: MobileReader, completion: @escaping (Bool) -> Void, error: @escaping (OmniException) -> Void)
 
   func refund(transaction: Transaction, refundAmount: Amount?, completion: @escaping (TransactionResult) -> Void, error: @escaping (OmniException) -> Void)
 
+  func void(transactionResult: TransactionResult, completion: @escaping (Bool) -> Void)
+
   func getConnectedReader(completion: (MobileReader?) -> Void, error: @escaping (OmniException) -> Void)
+}
+
+extension MobileReaderDriver {
+  func capture(transaction: Transaction, completion: @escaping (Bool) -> Void) {
+    print("MobileReaderDriver#capture not implemented")
+    completion(true)
+  }
+
+  func void(transactionResult: TransactionResult, completion: @escaping (Bool) -> Void) {
+    print("MobileReaderDriver#void not implemented")
+    completion(true)
+  }
 }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -135,13 +135,13 @@ class TakeMobileReaderPayment {
                       failedTransaction.message = "Error capturing the transaction"
 
                       // Fail the transaction in omni
-                      self.transactionRepository.update(model: failedTransaction, id: transactionId) { (updatedTransaction) in
+                      self.transactionRepository.update(model: failedTransaction, id: transactionId, completion: { _ in
                         voidAndFail(TakeMobileReaderPaymentException.couldNotCaptureTransaction)
                         return
-                      } error: { (error) in
+                      }, error: { _ in
                         voidAndFail(TakeMobileReaderPaymentException.couldNotCaptureTransaction)
                         return
-                      }
+                      })
                     }
                   }
                 }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -366,7 +366,7 @@ class TakeMobileReaderPayment {
 
       invoiceToCreate.meta = invoiceMetaJson
       invoiceRepository.create(model: invoiceToCreate, completion: { createdInvoice in
-        guard createdInvoice.id == "" else {
+        guard createdInvoice.id?.isEmpty != true else {
           return failure(TakeMobileReaderPaymentException.couldNotCreateInvoice(detail: nil))
         }
         completion(createdInvoice)

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -102,6 +102,10 @@ class TakeMobileReaderPayment {
 
           // This is a callback that voids the transaction and calls the fail block
           let voidAndFail: (OmniException) -> Void = { exception in
+
+            // By the time this is invoked, the NMI transaction went through fine but something happened while doing
+            // one of the calls to Omni. Since the transaction is pending confirmation, then we need to void it *before*
+            // invoking the failure block. That way the customer gets their money back
             driver.void(transactionResult: mobileReaderPaymentResult) { _ in
               failure(exception)
             }

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakeMobileReaderPayment.swift
@@ -12,6 +12,7 @@ enum TakeMobileReaderPaymentException: OmniException {
   case mobileReaderNotFound
   case mobileReaderNotReady
   case invoiceNotFound
+  case invoiceIdCannotBeBlank
   case couldNotCreateInvoice(detail: String?)
   case couldNotCreateCustomer(detail: String?)
   case couldNotCreatePaymentMethod(detail: String?)
@@ -45,6 +46,9 @@ enum TakeMobileReaderPaymentException: OmniException {
 
     case .couldNotCreateTransaction(let d):
       return d ?? "Could not create transaction"
+
+    case .invoiceIdCannotBeBlank:
+      return "Could not create invoice"
     }
   }
 
@@ -87,7 +91,6 @@ class TakeMobileReaderPayment {
     availableMobileReaderDriver(mobileReaderDriverRepository, failure) { driver in
 
       self.getOrCreateInvoice(failure) { (createdInvoice) in
-
         self.takeMobileReaderPayment(with: driver,
                                      signatureProvider: self.signatureProvider,
                                      transactionUpdateDelegate: self.transactionUpdateDelegate,
@@ -295,6 +298,7 @@ class TakeMobileReaderPayment {
                                            transactionUpdateDelegate: TransactionUpdateDelegate?,
                                            _ failure: (OmniException) -> Void,
                                            _ completion: @escaping (TransactionResult) -> Void) {
+    print("Performing transaction")
     driver.performTransaction(with: self.request, signatureProvider: signatureProvider, transactionUpdateDelegate: transactionUpdateDelegate, completion: completion)
   }
 
@@ -302,6 +306,10 @@ class TakeMobileReaderPayment {
   internal func getOrCreateInvoice(_ failure: @escaping (OmniException) -> Void, _ completion: @escaping (Invoice) -> Void) {
     // If an invoiceId was given in the transaction request, we should verify that an invoice with that id exists
     if let invoiceId = request.invoiceId {
+      guard !invoiceId.isEmpty else {
+        failure(TakeMobileReaderPaymentException.invoiceIdCannotBeBlank)
+        return
+      }
       invoiceRepository.getById(id: invoiceId, completion: completion) { (error) in
         failure(TakeMobileReaderPaymentException.invoiceNotFound)
       }
@@ -319,7 +327,12 @@ class TakeMobileReaderPayment {
       }
 
       invoiceToCreate.meta = invoiceMetaJson
-      invoiceRepository.create(model: invoiceToCreate, completion: completion, error: failure)
+      invoiceRepository.create(model: invoiceToCreate, completion: { createdInvoice in
+        guard createdInvoice.id == "" else {
+          return failure(TakeMobileReaderPaymentException.couldNotCreateInvoice(detail: nil))
+        }
+        completion(createdInvoice)
+      }, error: failure)
     }
   }
 

--- a/fattmerchant-ios-sdk/Models/MobileReader.swift
+++ b/fattmerchant-ios-sdk/Models/MobileReader.swift
@@ -28,7 +28,7 @@ public class MobileReader: CustomStringConvertible {
   public var serialNumber: String?
 
   /// The way that the iOS device connects to the reader. Bluetooth, BLE, etc
-  internal var connectionType: String? = nil
+  public var connectionType: String?
 
   /// Initialize a MobileReader by name
   ///
@@ -44,6 +44,24 @@ public class MobileReader: CustomStringConvertible {
     self.make = make
     self.model = model
     self.serialNumber = serialNumber
+  }
+
+  /// Initialize a MobileReader
+  ///
+  /// This name must match the real name of the mobile reader, or mobile reader operations will not work
+  /// - Parameter name: The name of the mobile reader
+  public init(name: String,
+              firmwareVersion: String? = nil,
+              make: String? = nil,
+              model: String? = nil,
+              serialNumber: String? = nil,
+              connectionType: String? = nil) {
+    self.name = name
+    self.firmwareVersion = firmwareVersion
+    self.make = make
+    self.model = model
+    self.serialNumber = serialNumber
+    self.connectionType = connectionType
   }
 
   public var description: String { return self.name }


### PR DESCRIPTION
# Release/1.4.5

### MOB-683 Check for blank invoice ids before taking mobile reader payment

[Github PR #56](https://github.com/fattmerchantorg/Fattmerchant-iOS-SDK/pull/56)
[Jira Ticket MOB-683](https://fattmerchant.atlassian.net/browse/MOB-683)

* Check for invoiceId that are empty strings before creating the transaction


### SPRINT-179 MOB-725 Confirm transaction after creating omni records

[Github PR #57](https://github.com/fattmerchantorg/Fattmerchant-iOS-SDK/pull/57)
[Jira Ticket MOB-725](https://fattmerchant.atlassian.net/browse/MOB-725)

* Added a `capture` and `void` method to `MobileReaderDriver`. These methods are  🔑  to the implementation of the new payment flow
* Added default implementations of capture and void because AWC doesn't support it yet, but the payments should still go through fine. AWC should just bypass the capture
* Changed the order of operations of `TakeMobileReaderPayment`. It will now do an auth in the mobile reader step, create all the records in Omni, and then capture the amount it authed
