### PR TITLE
[SPRINT-181][MOB-750] Actually include AWC in mobilereaderdriverrepo

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/Repository/MobileReaderDriverRepository.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Repository/MobileReaderDriverRepository.swift
@@ -19,11 +19,10 @@ class MobileReaderDriverRepository {
 
   #else
   var chipDnaDriver = ChipDnaDriver()
-//  var awcDriver = AWCDriver()
+  var awcDriver = AWCDriver()
 
   func allDrivers() -> [MobileReaderDriver] {
-    return [chipDnaDriver]
-//    return [chipDnaDriver, awcDriver]
+    return [chipDnaDriver, awcDriver]
   }
   #endif
 


### PR DESCRIPTION
## **[Ticket MOB-750](https://fattmerchant.atlassian.net/browse/MOB-750)**

> **iOS SDK 2.0.0 AWC | Unable to initialize with AWC merchant**

## What did I do?

> The mobile SDKs have a concept of Mobile Reader "Drivers". These are objects that know how to communicate with the different mobile readers that we support. We hide the functionality behind an interface named `MobileReaderDriver` so that we can write business logic code that doesn't care _which_ mobile reader we're talking to. There is another class called `MobileReaderDriverRepository` whose job it is to serve all the mobile reader drivers we support. 

- MobileReaderDriverRepo was not including AWCDriver in the allDrivers() return so it was impossible to init and use AWC. To fix this, I simply included the instance of `AWCDriver` in the array returned by allDrivers()


---

## PR notes contain:

* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:

* [x] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I created `data-testid` attributes for any new UI
* [x] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [x] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review
