### PR TITLE
[MOB-1162] Fix rounding issue in Amount(dollars:) initializer

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/Data/Amount.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Data/Amount.swift
@@ -38,6 +38,17 @@ public struct Amount {
   /// amount.cents // => 498
   /// ```
   public init(dollars: Double) {
+    // Use Decimal to get the exact product of dollars and 100
+    let centsDecimal = Decimal(dollars) * Decimal(100.0)
+
+    // Turn it to a string and take everything before the decimal place.
+    // This is a safe way to turn a Decimal into an Int
+    if let centsString = centsDecimal.description.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true).first,
+        let centsInt = Int(centsString) {
+      self.cents = centsInt
+      return
+    }
+
     self.cents = Int(dollars * 100.0)
   }
 

--- a/fattmerchant_ios_sdkTests/AmountTests.swift
+++ b/fattmerchant_ios_sdkTests/AmountTests.swift
@@ -12,6 +12,22 @@ class AmountTest: XCTestCase {
 
   func testInitWithDollars() {
     XCTAssertEqual(Amount(dollars: 5.9876).cents, 598)
+    XCTAssertEqual(Amount(dollars: 2.07).cents, 207)
+    XCTAssertEqual(Amount(dollars: 606.30).cents, 60630)
+
+    // This code below checks every dollar amount from min to max to make sure that the Amount object
+    // performs the dollars -> cents conversion correctly
+    let min = 0.0
+    let max = 1_000.0
+    let increment = 0.01
+
+    for dollars in stride(from: min, to: max, by: increment) {
+      let expectedCents = Decimal(dollars) * Decimal(100.0)
+      let expectedCentsInt = Int(expectedCents.description.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: true).first!)!
+      let amount = Amount(dollars: dollars)
+      XCTAssertEqual(amount.cents, expectedCentsInt)
+    }
+
   }
 
   func testCentsString() {
@@ -20,14 +36,17 @@ class AmountTest: XCTestCase {
     XCTAssertEqual(Amount(dollars: 50.30).centsString(), "5030")
     XCTAssertEqual(Amount(dollars: 50.309).centsString(), "5030")
     XCTAssertEqual(Amount(dollars: 0.09).centsString(), "9")
+    XCTAssertEqual(Amount(dollars: 606.30).centsString(), "60630")
   }
 
   func testDollarsString() {
     XCTAssertEqual(Amount(cents: 50).dollarsString(), "0.50")
+    XCTAssertEqual(Amount(cents: 60630).dollarsString(), "606.30")
     XCTAssertEqual(Amount(dollars: 50.30).dollarsString(), "50.30")
     XCTAssertEqual(Amount(dollars: 50.30).dollarsString(), "50.30")
     XCTAssertEqual(Amount(dollars: 50.309).dollarsString(), "50.30")
     XCTAssertEqual(Amount(dollars: 0.09).dollarsString(), "0.09")
+    XCTAssertEqual(Amount(dollars: 606.30).dollarsString(), "606.30")
   }
 
   func testPretty() {
@@ -36,6 +55,7 @@ class AmountTest: XCTestCase {
     XCTAssertEqual(Amount(dollars: 50.30).pretty(), "$50.30")
     XCTAssertEqual(Amount(dollars: 50.309).pretty(), "$50.30")
     XCTAssertEqual(Amount(dollars: 0.09).pretty(), "$0.09")
+    XCTAssertEqual(Amount(dollars: 606.30).pretty(), "$606.30")
   }
 
   func testDollars() {
@@ -44,6 +64,7 @@ class AmountTest: XCTestCase {
     XCTAssertEqual(Amount(dollars: 50.30).dollars(), 50.30)
     XCTAssertEqual(Amount(dollars: 50.309).dollars(), 50.30)
     XCTAssertEqual(Amount(dollars: 0.09).dollars(), 0.09)
+    XCTAssertEqual(Amount(dollars: 606.30).dollars(), 606.30)
   }
 
   func testGetCents() {
@@ -52,5 +73,6 @@ class AmountTest: XCTestCase {
     XCTAssertEqual(Amount(dollars: 50.30).cents, 5030)
     XCTAssertEqual(Amount(dollars: 50.309).cents, 5030)
     XCTAssertEqual(Amount(dollars: 0.09).cents, 9)
+    XCTAssertEqual(Amount(dollars: 606.30).cents, 60630)
   }
 }


### PR DESCRIPTION
https://fattmerchant.atlassian.net/browse/MOB-1162

## What is this
A merchant reported that their transactions were being captured for one cent less than they intended. For example, they typed in `$606.30` and the customer was charged `$606.29`

The SDK requires that it's users pass in an `Amount` in order to take transactions. [`Amount`](https://github.com/fattmerchantorg/Fattmerchant-iOS-SDK/blob/master/fattmerchant-ios-sdk/Cardpresent/Data/Amount.swift) is a class defined in the SDK. In order to avoid rounding issues, it takes the Double that is passed into it, converts it into an Int and stores it as an Int. Then it does integer arithmetic instead of floating point. 

[This is the line at fault](https://github.com/fattmerchantorg/Fattmerchant-iOS-SDK/blob/master/fattmerchant-ios-sdk/Cardpresent/Data/Amount.swift#L41)

```
  public init(dollars: Double) {
    self.cents = Int(dollars * 100.0)
  }
```

The reason the 606.30 number isn't working is because the Swift `Double` class can't represent the product of `606.30` and `100.0` as `60630`, and instead it shows `606.299999...`. 

## What did I do
Instead of doing the multiplication with `Double`, I made the initializer at fault do the multiplication using the [`Decimal` ](https://developer.apple.com/documentation/foundation/decimal) class. This does the math in base 10 and will give an exact answer every time. 

![5FC77F77-BBC0-4596-921B-B423071F0238](https://user-images.githubusercontent.com/5385681/158125484-9ea95f3d-bd27-4216-841b-ced7f81ef35f.png)

After doing the dollar * 100 math, i turn it into a string, remove the decimal and fractional value and it leaves the whole number that we're looking for

## Screenshots & Testing

Since we know which value didn't work for the merchant, I added that value to the test cases and it failed
![8810EE2F-3CB5-4060-95A2-C6951C9EA437](https://user-images.githubusercontent.com/5385681/158125545-e80f3001-bdef-420a-a8aa-b0e10453a32e.png)

Since we only tested a few numbers, I made a function that is able to test a range of numbers. It first failed for the 606 value, which was expected. 
![DD0281ED-08F7-4BB8-A2D7-47646DF23E87](https://user-images.githubusercontent.com/5385681/158125753-8d60e53b-b0cb-453b-ac69-750e0c64f9c4.png)

After performing the fix, I ran it for all the dollar values from 0 -> 1,000 and made sure that it worked for all of them. Note that this tests 0.0, 0.01, 0.02, ... 999.98, 999.99, 1000

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/5385681/158125852-5aa27642-ca2d-429e-9006-234de590a861.png">


Here's a screenshot of all the tests passing:
<img width="1544" alt="image" src="https://user-images.githubusercontent.com/5385681/158126260-445de102-4150-4586-a95f-5d807d90789b.png">

