### PR TITLE
Mob 1325

### DIFF
--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakePayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakePayment.swift
@@ -101,10 +101,20 @@ class TakePayment {
     /// - poNumber: The purchase order number for the transaction
   /// - Returns: a ChargeRequest
     internal static func createChargeRequest(amount: Amount, paymentMethodId: String, poNumber: String?  ) -> ChargeRequest {
-    let chargeRequestMeta = [
-      "subtotal": amount.dollarsString(),
-      "poNumber": poNumber ?? ""
-    ]
+    
+        let chargeRequestMeta :[String: String] = {
+            if poNumber != nil {
+                return [
+                    "subtotal": amount.dollarsString(),
+                    "poNumber": poNumber!
+                ]
+            } else {
+                return [
+                    "subtotal": amount.dollarsString()
+                ]
+            }
+        }()
+        
     return ChargeRequest(paymentMethodId: paymentMethodId,
                                       total: amount.dollarsString(),
                                       preAuth: false,

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakePayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakePayment.swift
@@ -67,7 +67,7 @@ class TakePayment {
       }
 
       // Create the request body
-      let chargeRequest = Self.createChargeRequest(amount: self.request.amount, paymentMethodId: paymentMethodId)
+        let chargeRequest = Self.createChargeRequest(amount: self.request.amount, paymentMethodId: paymentMethodId,poNumber: self.request.poNumber)
       let body = Data(chargeRequest: chargeRequest)
 
       // Make the request to Omni
@@ -99,11 +99,11 @@ class TakePayment {
   ///   - amount: the Amount to charge
   ///   - paymentMethodId: the id of the PaymentMethod to charge
   /// - Returns: a ChargeRequest
-  internal static func createChargeRequest(amount: Amount, paymentMethodId: String) -> ChargeRequest {
+    internal static func createChargeRequest(amount: Amount, paymentMethodId: String, poNumber: String?  ) -> ChargeRequest {
     let chargeRequestMeta = [
-      "subtotal": amount.dollarsString()
+      "subtotal": amount.dollarsString(),
+      "poNumber": poNumber ?? ""
     ]
-
     return ChargeRequest(paymentMethodId: paymentMethodId,
                                       total: amount.dollarsString(),
                                       preAuth: false,

--- a/fattmerchant-ios-sdk/Cardpresent/Usecase/TakePayment.swift
+++ b/fattmerchant-ios-sdk/Cardpresent/Usecase/TakePayment.swift
@@ -94,10 +94,11 @@ class TakePayment {
     return (job, nil)
   }
 
-  /// Creates a ChargeRequest from an Amount and a PaymentMethod id
+  /// Creates a ChargeRequest from an Amount and a PaymentMethod id, poNumber is optional
   /// - Parameters:
   ///   - amount: the Amount to charge
   ///   - paymentMethodId: the id of the PaymentMethod to charge
+    /// - poNumber: The purchase order number for the transaction
   /// - Returns: a ChargeRequest
     internal static func createChargeRequest(amount: Amount, paymentMethodId: String, poNumber: String?  ) -> ChargeRequest {
     let chargeRequestMeta = [

--- a/fattmerchant-ios-sdk/Utils/String+Blank.swift
+++ b/fattmerchant-ios-sdk/Utils/String+Blank.swift
@@ -5,6 +5,7 @@
 //  Created by Tulio Troncoso on 8/1/22.
 //  Copyright © 2022 Fattmerchant. All rights reserved.
 //
+import Foundation
 
 extension String {
 

--- a/fattmerchant_ios_sdkTests/Usecase/TakePaymentTests.swift
+++ b/fattmerchant_ios_sdkTests/Usecase/TakePaymentTests.swift
@@ -45,6 +45,24 @@ class TakePaymentTests: XCTestCase {
     XCTAssertEqual(chargeReq.paymentMethodId, paymentMethodId)
     XCTAssertEqual(chargeReq.total, "10.00")
   }
+    
+    func testCreateChargeRequestWhenPoNumberIsNil() {
+      let amount = Amount(dollars: 10.00)
+      let poNumber: String? = nil
+      let paymentMethodId = "123"
+      let chargeReq = TakePayment.createChargeRequest(amount: amount, paymentMethodId: paymentMethodId, poNumber: poNumber)
+
+      let expectedMeta = [
+        "subtotal": amount.dollarsString(),
+        "poNumber": poNumber ?? ""
+      ]
+      XCTAssertEqual(chargeReq.meta, expectedMeta)
+      XCTAssertEqual(chargeReq.preAuth, false)
+      XCTAssertEqual(chargeReq.paymentMethodId, paymentMethodId)
+      XCTAssertEqual(chargeReq.total, amount.dollarsString())
+    }
+    
+    
 
   func testCanTakePayment() {
     modelStore = [:]

--- a/fattmerchant_ios_sdkTests/Usecase/TakePaymentTests.swift
+++ b/fattmerchant_ios_sdkTests/Usecase/TakePaymentTests.swift
@@ -32,11 +32,13 @@ class TakePaymentTests: XCTestCase {
 
   func testCreateChargeRequest() {
     let amount = Amount(dollars: 10.00)
+    let poNumber = "asdf4terstges"
     let paymentMethodId = "123"
-    let chargeReq = TakePayment.createChargeRequest(amount: amount, paymentMethodId: paymentMethodId)
+    let chargeReq = TakePayment.createChargeRequest(amount: amount, paymentMethodId: paymentMethodId, poNumber: poNumber)
 
     let expectedMeta = [
-      "subtotal": "10.00"
+      "subtotal": "10.00",
+      "poNumber": poNumber
     ]
     XCTAssertEqual(chargeReq.meta, expectedMeta)
     XCTAssertEqual(chargeReq.preAuth, false)


### PR DESCRIPTION
## **[Ticket MOB-1325](https://fattmerchant.atlassian.net/browse/MOB-1325)**

> **Shipping amount and po number not showing in the payments or invoices pages**

## What did I do?

Fix bug on iOS SDK 2.2.1 | Shipping amount and po number not showing in the payments or invoices pages

---

<!-- YOU CAN DELETE THE SCREENSHOTS SECTION IF NOT APPLICABLE -->

## Screenshot(s):

* [Paste_screenshots_here]

---

## PR notes contain:

* [x] Checklist for any deployment dependencies (such as new env vars, back-end dependencies, etc)

## PR Checklist:

* [ ] **I tested this**
* [x] I updated from the base branch (usually `latest`)
* [x] I attached screenshot(s) (if there were UI changes)
* [x] I created `data-testid` attributes for any new UI
* [ ] I used the following PR title format: "[SPRINT-XX][fat-xx] BLAH"
  * Add "[EFS]" to the PR title if it was in the ticket title, e.g. "[SPRINT-XX][fat-xx][EFS]"
* [ ] I looked over the Files Changed tab
* [x] I consulted with the ticket's product owner (if necessary)
* [x] I requested a peer review


