### PR TITLE
fix(PHO-4826): Fix VP3350 crash error for TTP 2.10.0 branch

### DIFF
--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -673,10 +673,6 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         return
     }
 
-        onConnectAndConfigureCallback(nil)
-        return
-    }
-
         // Figure out the reader details and pass them along
         onConnectAndConfigureCallback(ChipDnaDriver.getConnectedReader())
     }

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -159,7 +159,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             }
             completion(connectedReader)
         }
-        print("reader name \(reader.name)")
+
         if reader.name.uppercased().hasPrefix("IDTECH") {
             requestParams.setValue(CCValueTrue, forKey: CCParamApplyFirmwareUpdate)
         }
@@ -177,7 +177,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             self,
             action: #selector(onDeviceUpdate(parameters:))
         )
-        print("connect and config 1")
+      
         ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }
 
@@ -204,7 +204,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             self,
             action: #selector(onTapConfigurationUpdate(parameters:))
         )
-   print("connect and config 2")
+
         ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }
 
@@ -658,7 +658,6 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         guard let onConnectAndConfigureCallback = onConnectAndConfigureCallback
         else { return }
         if parameters[CCParamResult] != CCValueTrue {
-            print("Hit on connect and config \((parameters[CCParamResult] as? String))")
             onConnectAndConfigureCallback(nil)
             return
         }

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -160,6 +160,8 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             completion(connectedReader)
         }
 
+        // requestParams.setValue(CCValueTrue, forKey: CCParamApplyFirmwareUpdate)
+
         ChipDnaMobile.sharedInstance()?.setProperties(requestParams)
         ChipDnaMobile.addConnectAndConfigureFinishedTarget(
             self,
@@ -173,7 +175,8 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             self,
             action: #selector(onDeviceUpdate(parameters:))
         )
-        ChipDnaMobile.sharedInstance()?.connectAndConfigure(nil)
+        print("connect and config 1")
+        ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }
 
     /// Connects to Tap to Pay via ChipDna and propagates success/failure.
@@ -199,7 +202,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             self,
             action: #selector(onTapConfigurationUpdate(parameters:))
         )
-
+   print("connect and config 2")
         ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }
 
@@ -647,12 +650,15 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     }
 
     @objc func onConnectAndConfigure(parameters: CCParameters) {
+       
         ChipDnaMobile.removeConnectAndConfigureFinishedTarget(self)
 
         guard let onConnectAndConfigureCallback = onConnectAndConfigureCallback
         else { return }
         if parameters[CCParamResult] != CCValueTrue {
+            print("Hit on connect and config \((parameters[CCParamResult] as? String))")
             onConnectAndConfigureCallback(nil)
+            return
         }
 
         // Figure out the reader details and pass them along

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -159,8 +159,10 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             }
             completion(connectedReader)
         }
-
-        // requestParams.setValue(CCValueTrue, forKey: CCParamApplyFirmwareUpdate)
+        print("reader name \(reader.name)")
+        if reader.name.uppercased().hasPrefix("IDTECH") {
+            requestParams.setValue(CCValueTrue, forKey: CCParamApplyFirmwareUpdate)
+        }
 
         ChipDnaMobile.sharedInstance()?.setProperties(requestParams)
         ChipDnaMobile.addConnectAndConfigureFinishedTarget(

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -342,11 +342,11 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
                 
                 // Get expiry date from card details if not already present
                 if let expiryDate = cardDetails[CCParamExpiryDate] {
-                    // Convert YYMM format to MM/YY format
+                    // Convert YYMM format to MMYY format
                     if expiryDate.count == 4 {
                         let yy = String(expiryDate.prefix(2))
                         let mm = String(expiryDate.suffix(2))
-                        transactionResult.cardExpiration = "\(mm)/\(yy)"
+                        transactionResult.cardExpiration = "\(mm)\(yy)"
                     }
                 }
             }

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -657,10 +657,25 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
 
         guard let onConnectAndConfigureCallback = onConnectAndConfigureCallback
         else { return }
+       
         if parameters[CCParamResult] != CCValueTrue {
-            onConnectAndConfigureCallback(nil)
-            return
-        }
+        // Check for error details
+        let errorCodes = parameters[CCParamErrors] ?? "Unknown"
+        let errorDescription = parameters[CCParamErrorDescription] ?? "No description"
+        let CCParamResult = parameters[CCParamResult] ?? "no ccparamresult"
+        
+        print("❌ Connection failed")
+        print("Error codes: \(errorCodes)")
+        print("Error description: \(errorDescription)")
+        print("CCParamResult: \(CCParamResult)")
+        
+        onConnectAndConfigureCallback(nil)
+        return
+    }
+
+        onConnectAndConfigureCallback(nil)
+        return
+    }
 
         // Figure out the reader details and pass them along
         onConnectAndConfigureCallback(ChipDnaDriver.getConnectedReader())

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -657,21 +657,10 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
 
         guard let onConnectAndConfigureCallback = onConnectAndConfigureCallback
         else { return }
-       
         if parameters[CCParamResult] != CCValueTrue {
-        // Check for error details
-        let errorCodes = parameters[CCParamErrors] ?? "Unknown"
-        let errorDescription = parameters[CCParamErrorDescription] ?? "No description"
-        let CCParamResult = parameters[CCParamResult] ?? "no ccparamresult"
-        
-        print("❌ Connection failed")
-        print("Error codes: \(errorCodes)")
-        print("Error description: \(errorDescription)")
-        print("CCParamResult: \(CCParamResult)")
-        
-        onConnectAndConfigureCallback(nil)
-        return
-    }
+            onConnectAndConfigureCallback(nil)
+            return
+        }
 
         // Figure out the reader details and pass them along
         onConnectAndConfigureCallback(ChipDnaDriver.getConnectedReader())


### PR DESCRIPTION
## What did I do?
- Added CCParamApplyFirmwareUpdate: true to chipDNA connectAndConfigure call when reader is a VP3350 to account for new requirements (for new SDK version)
- Updated the expiry date method to use MMYY format (to address a "the card_exp must be 4 characters" error which was caused by the formatting of the date with a /)
- Added a return statement in the event of a failed connectAndConfigure call