### PR TITLE
fix: eliminate NSGenericException crash in ChipDna callback targets

### DIFF
--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -14,11 +14,31 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     /// The ChipDna init params passed in the `initialize` function.
     private static var initializationArgs: ChipDnaInitializationArgs?
 
+    /// Serial queue used to hop off ChipDnaMobile's `runCallbackThread` before
+    /// mutating SDK state (dispose + re-initialize). Prevents re-entering the
+    /// target-list mutation path while ChipDnaMobile is still enumerating its
+    /// targets — the root cause class of the original crash.
+    private static let sdkMutationQueue = DispatchQueue(
+        label: "com.fattmerchant.chipdna.sdk-mutation"
+    )
+
+    /// Protects `callbackTargetsRegistered`, the three one-shot completion
+    /// closures, and `activeMode`. All of these are read on caller threads
+    /// (job queue, HardwareManager actor executor) and written on ChipDnaMobile's
+    /// `runCallbackThread`; a lock is required for memory-visibility, not just
+    /// mutual exclusion.
+    private let stateLock = NSLock()
+
     /// Guards one-time registration of ChipDnaMobile callback targets.
-    /// Registration is deferred until after `ChipDnaMobile.initialize()` has
-    /// succeeded, then happens on the first `searchForReaders`/`connect`/
-    /// `connectToTap` call and is never repeated.
+    /// Registration happens synchronously inside `initialize()` on success,
+    /// so the flag is `true` whenever the SDK is initialized.
     private var callbackTargetsRegistered = false
+
+    /// Scope for ConfigurationUpdate fan-out. Both reader and tap flows share
+    /// ChipDnaMobile's `configurationUpdate` event; gating handlers on the
+    /// active mode prevents cross-contamination of delegate calls between flows.
+    fileprivate enum ActiveMode { case none, reader, tap }
+    fileprivate var activeMode: ActiveMode = .none
 
     var familiarSerialNumbers: [String] = []
 
@@ -26,9 +46,22 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         super.init()
     }
 
-    weak var tapConnectionStatusDelegate: (any TapConnectionStatusDelegate)?
+    /// Delegate for reader (USB/BLE/BT) connection status updates.
+    ///
+    /// - Important: This is a singleton-scoped property. The SDK does **not**
+    ///   serialize assignment; callers must ensure only one flow assigns this
+    ///   delegate at a time. In practice, `HardwareManager`'s `connectContinuation`
+    ///   guard enforces this — future callers should preserve that invariant or
+    ///   wrap their own serialization. Late callbacks from a prior flow can
+    ///   leak into a newly-assigned delegate if that contract is broken.
     weak var mobileReaderConnectionStatusDelegate:
         MobileReaderConnectionStatusDelegate?
+
+    /// Delegate for Tap to Pay connection status updates.
+    ///
+    /// - Important: Same serialization contract as
+    ///   `mobileReaderConnectionStatusDelegate`. See its doc comment.
+    weak var tapConnectionStatusDelegate: (any TapConnectionStatusDelegate)?
 
     /// A block to run after self deserializes a list of SelectablePinPads from the result of ChipDna availablePinPads
     fileprivate var onAvailablePinPadsCallback: (([SelectablePinPad]) -> Void)?
@@ -64,11 +97,23 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         args: MobileReaderDriverInitializationArgs,
         completion: @escaping (Bool) -> Void
     ) {
-        // Re-init paths (e.g. auth change → app calls initialize again) may
-        // clear ChipDnaMobile's internal target list. Reset the one-shot flag
-        // so `registerCallbackTargetsIfNeeded()` re-runs on the next operation
-        // and our handlers are wired back up against the fresh SDK state.
+        // Atomically tear down transient state before ChipDnaMobile re-init:
+        //   - `callbackTargetsRegistered = false` so the upcoming SDK init
+        //     triggers fresh target registration against the new internal state.
+        //   - Nil out the three one-shot completion closures so any late
+        //     callback emitted during `dispose()` / `initialize()` can't consume
+        //     a pending completion that belongs to a prior (now-abandoned)
+        //     operation. This closes the re-init race window where an old
+        //     handler would nil a closure meant for the post-re-init attempt.
+        //   - Reset `activeMode` so stale config events from the old session
+        //     don't leak to either delegate during teardown.
+        stateLock.lock()
         callbackTargetsRegistered = false
+        onAvailablePinPadsCallback = nil
+        onConnectAndConfigureCallback = nil
+        onTapConnectAndConfigureCallback = nil
+        activeMode = .none
+        stateLock.unlock()
 
         guard let args = args as? ChipDnaInitializationArgs,
             !args.keys.securityKey.isEmpty
@@ -104,7 +149,13 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             return
         }
 
-        // Initialized
+        // Register callback targets synchronously against the fresh SDK state.
+        // Doing this here (rather than lazily on first connect) means the only
+        // context that ever mutates ChipDnaMobile's target list is this
+        // app-originated initialize path. `searchForReaders`/`connect`/
+        // `connectToTap` callers find the flag already set and skip registration.
+        registerCallbackTargetsIfNeeded()
+
         completion(true)
     }
 
@@ -141,22 +192,30 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     ) {
         // TODO: Allow scans for only USB, BLE, or BT based on args
 
+        // Fail fast if the SDK isn't initialized. Previously this path would
+        // silently no-op and the caller would dead-wait on a completion that
+        // never fires.
+        guard ChipDnaMobile.isInitialized() else {
+            completion([])
+            return
+        }
+
         // Scan everything for 5 seconds
         let params = CCParameters()
         params[CCParamBLEScanTime] = "5"
 
-        // Set the callback to contain this function's completion parameter
+        // Set the callback to contain this function's completion parameter.
+        // Targets were registered in `initialize()`; the singleton holds them
+        // for the process lifetime and handlers route on the nil-ness of this
+        // closure.
+        stateLock.lock()
         onAvailablePinPadsCallback = { availablePinPads in
             let readers = availablePinPads.map({ MobileReader.from(pinPad: $0) }
             )
             completion(readers)
         }
+        stateLock.unlock()
 
-        // Target registration is one-shot for the process; see
-        // `registerCallbackTargetsIfNeeded()`. Do NOT add/remove targets
-        // here — mutating ChipDnaMobile's target list around callbacks
-        // is what caused the enumeration-mutation crash.
-        registerCallbackTargetsIfNeeded()
         ChipDnaMobile.sharedInstance()?.getAvailablePinPads(params)
     }
 
@@ -167,11 +226,22 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         reader: MobileReader,
         completion: @escaping (MobileReader?) -> Void
     ) {
+        // Fail fast if the SDK isn't initialized.
+        guard ChipDnaMobile.isInitialized() else {
+            completion(nil)
+            return
+        }
+
         let requestParams = CCParameters()
         requestParams[CCParamPinPadName] = reader.name
         requestParams[CCParamPinPadConnectionType] =
             reader.connectionType ?? CCValueBLE
 
+        // Claim the reader flow's event scope before arming the callback. This
+        // gates `onConfigurationUpdate` / `onDeviceUpdate` fan-out to the reader
+        // delegate and keeps tap-session events from leaking into it.
+        stateLock.lock()
+        activeMode = .reader
         onConnectAndConfigureCallback = { connectedReader in
             let _ = ChipDnaMobile.sharedInstance().getStatus(nil)
             if let connectedReader = connectedReader,
@@ -181,19 +251,13 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             }
             completion(connectedReader)
         }
+        stateLock.unlock()
 
         if reader.name.uppercased().hasPrefix("IDTECH") {
             requestParams.setValue(CCValueTrue, forKey: CCParamApplyFirmwareUpdate)
         }
 
         ChipDnaMobile.sharedInstance()?.setProperties(requestParams)
-        // All callback targets (finished, configuration update, device update)
-        // are registered once by `registerCallbackTargetsIfNeeded()` for the
-        // process lifetime. Handlers route on pending-completion state
-        // (nil-ness of `onConnectAndConfigureCallback`) and delegate
-        // nullability, not on registration presence.
-        registerCallbackTargetsIfNeeded()
-
         ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }
 
@@ -201,21 +265,26 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     func connectToTap(
         completion: @escaping (Bool, OmniException?) -> Void
     ) {
+        // Fail fast if the SDK isn't initialized.
+        guard ChipDnaMobile.isInitialized() else {
+            completion(false, OmniGeneralException.uninitialized)
+            return
+        }
+
         let requestParams = CCParameters()
         requestParams.setValue(CCValueTrue, forKey: CCParamTapToMobilePOI)
         requestParams.setValue(CCValueFalse, forKey: CCParamPaymentDevicePOI)
-        
+
         ChipDnaMobile.sharedInstance()?.getStatus(nil)
 
+        // Claim the tap flow's event scope before arming the callback, for the
+        // same reason `connect()` does.
+        stateLock.lock()
+        activeMode = .tap
         onTapConnectAndConfigureCallback = { success, error in
             completion(success, error)
         }
-
-        // All TTP callback targets (finished, tap configuration update) are
-        // registered once by `registerCallbackTargetsIfNeeded()`; the
-        // handler guards on `onTapConnectAndConfigureCallback` being non-nil,
-        // so only the active TTP flow consumes the event.
-        registerCallbackTargetsIfNeeded()
+        stateLock.unlock()
 
         ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }
@@ -241,16 +310,33 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         completion: @escaping (Bool) -> Void,
         error: @escaping (OmniException) -> Void
     ) {
-        if !ChipDnaMobile.isInitialized() {
+        guard ChipDnaMobile.isInitialized() else {
             error(OmniGeneralException.uninitialized)
+            return
         }
 
-        // Re-initializing the ChipDnaMobile SDK disconnects everything, so that works.
-        ChipDnaMobile.dispose(nil)
-        initialize(
-            args: ChipDnaDriver.initializationArgs!,
-            completion: completion
-        )
+        guard let args = ChipDnaDriver.initializationArgs else {
+            error(OmniGeneralException.uninitialized)
+            return
+        }
+
+        // Hop off any ChipDnaMobile callback thread before touching the SDK's
+        // target list. `dispose()` synchronously fires final callbacks; if
+        // `disconnect()` was invoked from within one of those callbacks (e.g.
+        // a delegate reacting to a status update), performing the dispose +
+        // re-initialize inline would mutate ChipDnaMobile's target list while
+        // it's still being enumerated — the exact pattern that caused the
+        // original crash. Serializing onto `sdkMutationQueue` guarantees the
+        // target list is only touched from a non-callback context.
+        ChipDnaDriver.sdkMutationQueue.async { [weak self] in
+            guard let self = self else {
+                completion(false)
+                return
+            }
+            // Re-initializing the ChipDnaMobile SDK disconnects everything, so that works.
+            ChipDnaMobile.dispose(nil)
+            self.initialize(args: args, completion: completion)
+        }
     }
 
     func performTransaction(
@@ -643,15 +729,25 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     // MARK: - ChipDna Listeners
 
     /// Registers all crash-path callback targets with ChipDnaMobile exactly
-    /// once. These targets remain registered for the lifetime of the process;
-    /// handlers below use the captured completion closure (nil-ing it after
-    /// firing) as the "has pending request" signal rather than presence in
-    /// the SDK's target list. This eliminates the need to mutate the target
-    /// list from inside a callback, which was the source of
+    /// once per SDK initialization. Called synchronously from `initialize()`
+    /// on success; `searchForReaders` / `connect` / `connectToTap` no longer
+    /// call this path. Handlers use the captured completion closure (nil-ing
+    /// it after firing) as the "has pending request" signal rather than
+    /// presence in the SDK's target list. This eliminates the need to mutate
+    /// the target list from inside a callback, which was the source of
     /// `NSGenericException: "Collection was mutated while being enumerated"`.
     fileprivate func registerCallbackTargetsIfNeeded() {
-        guard !callbackTargetsRegistered else { return }
-        guard ChipDnaMobile.isInitialized() else { return }
+        stateLock.lock()
+        if callbackTargetsRegistered {
+            stateLock.unlock()
+            return
+        }
+        guard ChipDnaMobile.isInitialized() else {
+            stateLock.unlock()
+            return
+        }
+        callbackTargetsRegistered = true
+        stateLock.unlock()
 
         ChipDnaMobile.addAvailablePinPadsTarget(
             self,
@@ -669,8 +765,8 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         // They were previously added per-`connect()` call, which was fine when
         // each call used a fresh driver instance; on the shared singleton that
         // pattern would stack duplicate (target, selector) pairs on every
-        // connect cycle. Handlers are idempotent fan-outs to a weak delegate,
-        // so one-shot registration is strictly correct.
+        // connect cycle. Scoping is now handled in the handlers themselves
+        // via `activeMode`, so one-shot registration is strictly correct.
         ChipDnaMobile.addConfigurationUpdateTarget(
             self,
             action: #selector(onConfigurationUpdate(parameters:))
@@ -683,18 +779,21 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             self,
             action: #selector(onDeviceUpdate(parameters:))
         )
-        callbackTargetsRegistered = true
     }
 
     @objc public func onAvailablePinPads(parameters: CCParameters) {
-        // Single-fire guard: capture locally and clear before invoking.
-        // Target stays registered for the process lifetime; this nil-out
-        // is how we track "no pending search" without mutating the SDK's
-        // target list from inside its own enumeration.
-        guard let onAvailablePinPadsCallback = onAvailablePinPadsCallback else {
-            return
-        }
-        self.onAvailablePinPadsCallback = nil
+        // Single-fire guard: capture-and-clear atomically under `stateLock` so
+        // two concurrent callback-thread invocations can't both read non-nil
+        // before either nil-outs. Target stays registered for the lifetime of
+        // the SDK init; this nil-out is how we track "no pending search"
+        // without mutating the SDK's target list from inside its own
+        // enumeration.
+        stateLock.lock()
+        let callback = onAvailablePinPadsCallback
+        onAvailablePinPadsCallback = nil
+        stateLock.unlock()
+
+        guard let callback = callback else { return }
 
         // Attempt deserialization
         guard
@@ -703,52 +802,56 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
                 pinPadsXml: availablePinPadsXml
             )
         else {
-            onAvailablePinPadsCallback([])
+            callback([])
             return
         }
 
-        onAvailablePinPadsCallback(pinPads)
+        callback(pinPads)
     }
 
     @objc func onConnectAndConfigure(parameters: CCParameters) {
-        // Single-fire guard. `onTapConnectAndConfigure` shares the same
-        // ChipDnaMobile event; nil-check ensures only the originating flow
-        // (regular reader connect) consumes this invocation.
-        guard let onConnectAndConfigureCallback = onConnectAndConfigureCallback
-        else { return }
-        self.onConnectAndConfigureCallback = nil
+        // Single-fire guard under `stateLock`. `onTapConnectAndConfigure`
+        // shares the same ChipDnaMobile event; nil-check ensures only the
+        // originating flow (regular reader connect) consumes this invocation.
+        stateLock.lock()
+        let callback = onConnectAndConfigureCallback
+        onConnectAndConfigureCallback = nil
+        stateLock.unlock()
+
+        guard let callback = callback else { return }
+
         if parameters[CCParamResult] != CCValueTrue {
-            onConnectAndConfigureCallback(nil)
+            callback(nil)
             return
         }
 
         // Figure out the reader details and pass them along
-        onConnectAndConfigureCallback(ChipDnaDriver.getConnectedReader())
+        callback(ChipDnaDriver.getConnectedReader())
     }
 
     @objc func onTapConnectAndConfigure(parameters: CCParameters) {
-        // Single-fire guard. Shares the `connectAndConfigureFinished` event
-        // with `onConnectAndConfigure`; nil-check ensures only the active
-        // TTP flow consumes this invocation.
-        guard let onTapConnectAndConfigureCallback =
-            onTapConnectAndConfigureCallback
-        else {
-            return
-        }
-        self.onTapConnectAndConfigureCallback = nil
+        // Single-fire guard under `stateLock`. Shares the
+        // `connectAndConfigureFinished` event with `onConnectAndConfigure`;
+        // nil-check ensures only the active TTP flow consumes this invocation.
+        stateLock.lock()
+        let callback = onTapConnectAndConfigureCallback
+        onTapConnectAndConfigureCallback = nil
+        stateLock.unlock()
+
+        guard let callback = callback else { return }
 
         let result = parameters[CCParamResult]
         if result == CCValueTrue {
             tapConnectionStatusDelegate?.tapConnectionStatusUpdate(
                 status: .connected
             )
-            onTapConnectAndConfigureCallback(true, nil)
+            callback(true, nil)
         } else {
             // Parse error codes and map to specific exceptions
             let exception = parseTapConnectionError(parameters: parameters)
-            onTapConnectAndConfigureCallback(false, exception)
+            callback(false, exception)
         }
-        
+
         ChipDnaMobile.sharedInstance().getStatus(nil)
     }
     
@@ -841,6 +944,15 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     }
 
     @objc func onConfigurationUpdate(parameters: CCParameters) {
+        // Gate on `activeMode == .reader`. Both reader and tap flows register
+        // handlers against ChipDnaMobile's `configurationUpdate` event on the
+        // singleton; without this gate, tap-session config events would fan
+        // out to `mobileReaderConnectionStatusDelegate` and vice versa.
+        stateLock.lock()
+        let mode = activeMode
+        stateLock.unlock()
+        guard mode == .reader else { return }
+
         if let str = parameters[CCParamConfigurationUpdate],
             let status = MobileReaderConnectionStatus(
                 chipDnaConfigurationUpdate: str
@@ -852,6 +964,12 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     }
 
     @objc func onTapConfigurationUpdate(parameters: CCParameters) {
+        // Gate on `activeMode == .tap`. See `onConfigurationUpdate` for rationale.
+        stateLock.lock()
+        let mode = activeMode
+        stateLock.unlock()
+        guard mode == .tap else { return }
+
         // Handle configuration update status
         if let str = parameters[CCParamConfigurationUpdate],
             let status = TapConnectionStatus(
@@ -862,7 +980,7 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
                 status: status
             )
         }
-        
+
         // Handle configuration percentage (0-100)
         // This is received after CCValueUpdatingTapToMobileConfig
         if let percentageStr = parameters[CCParamTapToMobileConfigurationPercentage],
@@ -876,6 +994,14 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     }
 
     @objc func onDeviceUpdate(parameters: CCParameters) {
+        // Device-status updates are meaningful only to the reader flow. The
+        // tap flow uses its own configuration events to signal connection
+        // state, not device-status events.
+        stateLock.lock()
+        let mode = activeMode
+        stateLock.unlock()
+        guard mode == .reader else { return }
+
         if let deviceStatusXml = parameters[CCParamDeviceStatusUpdate],
             let deviceStatus = ChipDnaMobileSerializer.deserializeDeviceStatus(
                 deviceStatusXml

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -265,9 +265,16 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     func connectToTap(
         completion: @escaping (Bool, OmniException?) -> Void
     ) {
-        // Fail fast if the SDK isn't initialized.
+        // Fail fast if the SDK isn't initialized. `ConnectToTapJob` force-casts
+        // the returned error to `ConnectTapException`, so the error type here
+        // must be a `ConnectTapException` variant — not `OmniGeneralException`.
         guard ChipDnaMobile.isInitialized() else {
-            completion(false, OmniGeneralException.uninitialized)
+            completion(
+                false,
+                ConnectTapException.couldNotConnectToTap(
+                    detail: "SDK not initialized"
+                )
+            )
             return
         }
 
@@ -296,8 +303,9 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         completion: (MobileReader?) -> Void,
         error: @escaping (OmniException) -> Void
     ) {
-        if !ChipDnaMobile.isInitialized() {
+        guard ChipDnaMobile.isInitialized() else {
             error(OmniGeneralException.uninitialized)
+            return
         }
 
         completion(ChipDnaDriver.getConnectedReader())

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -4,10 +4,27 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     static var isStaxRefundsSupported: Bool = true
     static var source: String = "NMI"
 
+    /// Process-long-lived singleton. Required so our ChipDnaMobile callback
+    /// targets (`self`) are registered exactly once and never mutated from
+    /// inside a callback — mutating ChipDnaMobile's target list during its
+    /// own enumeration aborts with `NSGenericException: "Collection was
+    /// mutated while being enumerated"` on `runCallbackThread`.
+    static let shared = ChipDnaDriver()
+
     /// The ChipDna init params passed in the `initialize` function.
     private static var initializationArgs: ChipDnaInitializationArgs?
 
+    /// Guards one-time registration of ChipDnaMobile callback targets.
+    /// Registration is deferred until after `ChipDnaMobile.initialize()` has
+    /// succeeded, then happens on the first `searchForReaders`/`connect`/
+    /// `connectToTap` call and is never repeated.
+    private var callbackTargetsRegistered = false
+
     var familiarSerialNumbers: [String] = []
+
+    private override init() {
+        super.init()
+    }
 
     weak var tapConnectionStatusDelegate: (any TapConnectionStatusDelegate)?
     weak var mobileReaderConnectionStatusDelegate:
@@ -129,12 +146,11 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             completion(readers)
         }
 
-        // Remove extraneous listeners, and search for available pin pads.
-        ChipDnaMobile.removeAvailablePinPadsTarget(self)
-        ChipDnaMobile.addAvailablePinPadsTarget(
-            self,
-            action: #selector(onAvailablePinPads(parameters:))
-        )
+        // Target registration is one-shot for the process; see
+        // `registerCallbackTargetsIfNeeded()`. Do NOT add/remove targets
+        // here — mutating ChipDnaMobile's target list around callbacks
+        // is what caused the enumeration-mutation crash.
+        registerCallbackTargetsIfNeeded()
         ChipDnaMobile.sharedInstance()?.getAvailablePinPads(params)
     }
 
@@ -165,19 +181,13 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         }
 
         ChipDnaMobile.sharedInstance()?.setProperties(requestParams)
-        ChipDnaMobile.addConnectAndConfigureFinishedTarget(
-            self,
-            action: #selector(onConnectAndConfigure(parameters:))
-        )
-        ChipDnaMobile.addConfigurationUpdateTarget(
-            self,
-            action: #selector(onConfigurationUpdate(parameters:))
-        )
-        ChipDnaMobile.addDeviceUpdateTarget(
-            self,
-            action: #selector(onDeviceUpdate(parameters:))
-        )
-      
+        // All callback targets (finished, configuration update, device update)
+        // are registered once by `registerCallbackTargetsIfNeeded()` for the
+        // process lifetime. Handlers route on pending-completion state
+        // (nil-ness of `onConnectAndConfigureCallback`) and delegate
+        // nullability, not on registration presence.
+        registerCallbackTargetsIfNeeded()
+
         ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }
 
@@ -195,15 +205,11 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             completion(success, error)
         }
 
-        ChipDnaMobile.addConnectAndConfigureFinishedTarget(
-            self,
-            action: #selector(onTapConnectAndConfigure(parameters:))
-        )
-
-        ChipDnaMobile.addConfigurationUpdateTarget(
-            self,
-            action: #selector(onTapConfigurationUpdate(parameters:))
-        )
+        // All TTP callback targets (finished, tap configuration update) are
+        // registered once by `registerCallbackTargetsIfNeeded()`; the
+        // handler guards on `onTapConnectAndConfigureCallback` being non-nil,
+        // so only the active TTP flow consumes the event.
+        registerCallbackTargetsIfNeeded()
 
         ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }
@@ -630,12 +636,59 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
 
     // MARK: - ChipDna Listeners
 
-    @objc public func onAvailablePinPads(parameters: CCParameters) {
-        ChipDnaMobile.removeAvailablePinPadsTarget(self)
+    /// Registers all crash-path callback targets with ChipDnaMobile exactly
+    /// once. These targets remain registered for the lifetime of the process;
+    /// handlers below use the captured completion closure (nil-ing it after
+    /// firing) as the "has pending request" signal rather than presence in
+    /// the SDK's target list. This eliminates the need to mutate the target
+    /// list from inside a callback, which was the source of
+    /// `NSGenericException: "Collection was mutated while being enumerated"`.
+    fileprivate func registerCallbackTargetsIfNeeded() {
+        guard !callbackTargetsRegistered else { return }
+        guard ChipDnaMobile.isInitialized() else { return }
 
+        ChipDnaMobile.addAvailablePinPadsTarget(
+            self,
+            action: #selector(onAvailablePinPads(parameters:))
+        )
+        ChipDnaMobile.addConnectAndConfigureFinishedTarget(
+            self,
+            action: #selector(onConnectAndConfigure(parameters:))
+        )
+        ChipDnaMobile.addConnectAndConfigureFinishedTarget(
+            self,
+            action: #selector(onTapConnectAndConfigure(parameters:))
+        )
+        // ConfigurationUpdate and DeviceUpdate targets register here too.
+        // They were previously added per-`connect()` call, which was fine when
+        // each call used a fresh driver instance; on the shared singleton that
+        // pattern would stack duplicate (target, selector) pairs on every
+        // connect cycle. Handlers are idempotent fan-outs to a weak delegate,
+        // so one-shot registration is strictly correct.
+        ChipDnaMobile.addConfigurationUpdateTarget(
+            self,
+            action: #selector(onConfigurationUpdate(parameters:))
+        )
+        ChipDnaMobile.addConfigurationUpdateTarget(
+            self,
+            action: #selector(onTapConfigurationUpdate(parameters:))
+        )
+        ChipDnaMobile.addDeviceUpdateTarget(
+            self,
+            action: #selector(onDeviceUpdate(parameters:))
+        )
+        callbackTargetsRegistered = true
+    }
+
+    @objc public func onAvailablePinPads(parameters: CCParameters) {
+        // Single-fire guard: capture locally and clear before invoking.
+        // Target stays registered for the process lifetime; this nil-out
+        // is how we track "no pending search" without mutating the SDK's
+        // target list from inside its own enumeration.
         guard let onAvailablePinPadsCallback = onAvailablePinPadsCallback else {
             return
         }
+        self.onAvailablePinPadsCallback = nil
 
         // Attempt deserialization
         guard
@@ -652,11 +705,12 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     }
 
     @objc func onConnectAndConfigure(parameters: CCParameters) {
-       
-        ChipDnaMobile.removeConnectAndConfigureFinishedTarget(self)
-
+        // Single-fire guard. `onTapConnectAndConfigure` shares the same
+        // ChipDnaMobile event; nil-check ensures only the originating flow
+        // (regular reader connect) consumes this invocation.
         guard let onConnectAndConfigureCallback = onConnectAndConfigureCallback
         else { return }
+        self.onConnectAndConfigureCallback = nil
         if parameters[CCParamResult] != CCValueTrue {
             onConnectAndConfigureCallback(nil)
             return
@@ -667,13 +721,15 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
     }
 
     @objc func onTapConnectAndConfigure(parameters: CCParameters) {
-        ChipDnaMobile.removeConnectAndConfigureFinishedTarget(self)
-
+        // Single-fire guard. Shares the `connectAndConfigureFinished` event
+        // with `onConnectAndConfigure`; nil-check ensures only the active
+        // TTP flow consumes this invocation.
         guard let onTapConnectAndConfigureCallback =
             onTapConnectAndConfigureCallback
         else {
             return
         }
+        self.onTapConnectAndConfigureCallback = nil
 
         let result = parameters[CCParamResult]
         if result == CCValueTrue {

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -64,6 +64,12 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         args: MobileReaderDriverInitializationArgs,
         completion: @escaping (Bool) -> Void
     ) {
+        // Re-init paths (e.g. auth change → app calls initialize again) may
+        // clear ChipDnaMobile's internal target list. Reset the one-shot flag
+        // so `registerCallbackTargetsIfNeeded()` re-runs on the next operation
+        // and our handlers are wired back up against the fresh SDK state.
+        callbackTargetsRegistered = false
+
         guard let args = args as? ChipDnaInitializationArgs,
             !args.keys.securityKey.isEmpty
         else {

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -98,6 +98,11 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         completion: @escaping (Bool) -> Void
     ) {
         // Atomically tear down transient state before ChipDnaMobile re-init:
+        //   - Capture any in-flight one-shot completion closures so we can
+        //     resume their upstream awaiters with a synthetic failure. Without
+        //     this, nil-ing a pending closure silently orphans the caller's
+        //     async continuation (e.g. `HardwareManager.tapConnectContinuation`),
+        //     producing a permanent "alreadyConnecting" state until app restart.
         //   - `callbackTargetsRegistered = false` so the upcoming SDK init
         //     triggers fresh target registration against the new internal state.
         //   - Nil out the three one-shot completion closures so any late
@@ -108,12 +113,27 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         //   - Reset `activeMode` so stale config events from the old session
         //     don't leak to either delegate during teardown.
         stateLock.lock()
+        let pendingAvailablePinPads = onAvailablePinPadsCallback
+        let pendingConnectAndConfigure = onConnectAndConfigureCallback
+        let pendingTapConnectAndConfigure = onTapConnectAndConfigureCallback
         callbackTargetsRegistered = false
         onAvailablePinPadsCallback = nil
         onConnectAndConfigureCallback = nil
         onTapConnectAndConfigureCallback = nil
         activeMode = .none
         stateLock.unlock()
+
+        // Fire the captured closures OUTSIDE the lock — they may re-enter the
+        // driver (e.g. a completion handler that immediately kicks off another
+        // SDK call). Holding `stateLock` across that re-entry would deadlock.
+        pendingAvailablePinPads?([])
+        pendingConnectAndConfigure?(nil)
+        pendingTapConnectAndConfigure?(
+            false,
+            ConnectTapException.couldNotConnectToTap(
+                detail: "SDK re-initialized"
+            )
+        )
 
         guard let args = args as? ChipDnaInitializationArgs,
             !args.keys.securityKey.isEmpty

--- a/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift
@@ -228,13 +228,26 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         // Targets were registered in `initialize()`; the singleton holds them
         // for the process lifetime and handlers route on the nil-ness of this
         // closure.
+        //
+        // If a prior call's closure is still parked (caller abandoned the
+        // attempt before ChipDnaMobile fired its event), we must invoke it
+        // with an empty result BEFORE overwriting — otherwise the previous
+        // closure's captured `CheckedContinuation` in
+        // `SearchForMobileReadersJob.start()` deinits un-resumed and Swift
+        // runtime logs: "SWIFT TASK CONTINUATION MISUSE: start() leaked its
+        // continuation without resuming it."
         stateLock.lock()
+        let previousAvailablePinPads = onAvailablePinPadsCallback
         onAvailablePinPadsCallback = { availablePinPads in
             let readers = availablePinPads.map({ MobileReader.from(pinPad: $0) }
             )
             completion(readers)
         }
         stateLock.unlock()
+
+        // Fire the superseded closure outside the lock so it can re-enter the
+        // driver without deadlocking.
+        previousAvailablePinPads?([])
 
         ChipDnaMobile.sharedInstance()?.getAvailablePinPads(params)
     }
@@ -260,7 +273,13 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
         // Claim the reader flow's event scope before arming the callback. This
         // gates `onConfigurationUpdate` / `onDeviceUpdate` fan-out to the reader
         // delegate and keeps tap-session events from leaking into it.
+        //
+        // Capture any stale pending closure first and invoke it with `nil`
+        // (failure) after releasing the lock. Same reasoning as in
+        // `searchForReaders`: overwriting without invoking orphans the prior
+        // closure's continuation in `ConnectToMobileReaderJob.start()`.
         stateLock.lock()
+        let previousConnectAndConfigure = onConnectAndConfigureCallback
         activeMode = .reader
         onConnectAndConfigureCallback = { connectedReader in
             let _ = ChipDnaMobile.sharedInstance().getStatus(nil)
@@ -272,6 +291,8 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
             completion(connectedReader)
         }
         stateLock.unlock()
+
+        previousConnectAndConfigure?(nil)
 
         if reader.name.uppercased().hasPrefix("IDTECH") {
             requestParams.setValue(CCValueTrue, forKey: CCParamApplyFirmwareUpdate)
@@ -306,12 +327,33 @@ class ChipDnaDriver: NSObject, MobileReaderDriver, TapDriver {
 
         // Claim the tap flow's event scope before arming the callback, for the
         // same reason `connect()` does.
+        //
+        // Capture any stale pending closure from a prior (abandoned) tap
+        // attempt so we can invoke it with a "superseded" failure BEFORE
+        // overwriting the slot. Without this, the prior closure's captured
+        // `CheckedContinuation` in `ConnectToTapJob.start()` would deinit
+        // un-resumed and Swift runtime would log:
+        //   "SWIFT TASK CONTINUATION MISUSE: start() leaked its continuation
+        //    without resuming it."
+        // This happens in practice when the app cancels a tap-connect mid
+        // flight (e.g. user dismisses the TTP prep screen) but ChipDnaMobile
+        // never fires its `connectAndConfigureFinished` event, leaving the
+        // closure parked in this slot until the next attempt overwrites it.
         stateLock.lock()
+        let previousTapConnectAndConfigure = onTapConnectAndConfigureCallback
         activeMode = .tap
         onTapConnectAndConfigureCallback = { success, error in
             completion(success, error)
         }
         stateLock.unlock()
+
+        // Fire outside the lock — caller may re-enter the driver.
+        previousTapConnectAndConfigure?(
+            false,
+            ConnectTapException.couldNotConnectToTap(
+                detail: "superseded by new connectToTap attempt"
+            )
+        )
 
         ChipDnaMobile.sharedInstance()?.connectAndConfigure(requestParams)
     }

--- a/Sources/Fattmerchant/Cardpresent/Omni/Repository/MobileReaderDriverRepository.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Repository/MobileReaderDriverRepository.swift
@@ -9,7 +9,7 @@ class MobileReaderDriverRepository {
     #if targetEnvironment(simulator)
       return [MockDriver()]
     #else
-      return [ChipDnaDriver()]
+      return [ChipDnaDriver.shared]
     #endif
   }
 

--- a/Sources/Fattmerchant/Cardpresent/Omni/Repository/TapPaymentDriverRepository.swift
+++ b/Sources/Fattmerchant/Cardpresent/Omni/Repository/TapPaymentDriverRepository.swift
@@ -7,7 +7,7 @@ class TapPaymentDriverRepository {
       #if targetEnvironment(simulator)
         return [MockDriver()]
       #else
-        return [ChipDnaDriver()]
+        return [ChipDnaDriver.shared]
       #endif
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `NSGenericException: "Collection was mutated while being enumerated"` crash at `-[ChipDnaMobile carryOutCallback:]` on `runCallbackThread`. Five prod crashes on iPhone 17 Pro / iOS 26.4.1 since 2026-04-09 (one day after TTP was enabled for users).

## Root cause

Three `@objc` callback handlers in `ChipDnaDriver` — `onAvailablePinPads`, `onConnectAndConfigure`, `onTapConnectAndConfigure` — were calling `ChipDnaMobile.remove*Target(self)` synchronously inside their own callback. ChipDnaMobile dispatches callbacks by enumerating its NSMutableArray target list, so `removeTarget` from within the callback mutated the collection mid-enumeration → SIGABRT.

Confirmed from SDK logs on both outcomes:
- **VP3350** `PinPadConnectionTimeout` (fail): crash at +8ms after callback
- **BBPOS** `TMS_UPDATE_UTC` (success): crash at +425ms after callback

So the trigger is the mutation itself, not any specific result code.

### Why now

- Bug landed in commit `32c1c38` on 2025-03-12 but the self-deregistering path was rarely hit by regular mobile-reader connects.
- `PHO-4636` HardwareManager actor refactor (2026-04-01) increased connect call volume.
- `PHO-4746` TTP flag activation on 2026-04-08 added a *third* self-deregistering handler (`onTapConnectAndConfigure`) on the same shared `connectAndConfigureFinished` event.
- First crash: 2026-04-09.

## Fix — architectural

Replaces per-instance register/deregister churn with a process-long-lived singleton + one-shot lazy registration:

- `ChipDnaDriver` becomes `ChipDnaDriver.shared`; private `init()` prevents external instantiation.
- All six ChipDnaMobile callback targets (`availablePinPads`, `connectAndConfigureFinished` ×2 for regular + TTP, `configurationUpdate` ×2 for regular + TTP, `deviceUpdate`) register exactly once via `registerCallbackTargetsIfNeeded()`. Guarded by `ChipDnaMobile.isInitialized()` and a one-shot `Bool` flag. Registration is lazy (triggered from `searchForReaders`/`connect`/`connectToTap`) so it lands *after* `initialize()` has succeeded.
- Handlers stop calling `remove*Target`. They now use nil-out of the captured completion closure as single-fire state: `guard let` the instance property, nil it, then invoke. `onConnectAndConfigure` and `onTapConnectAndConfigure` share the `connectAndConfigureFinished` event; nil-ness of the appropriate callback disambiguates regular vs TTP flows.
- `MobileReaderDriverRepository.all()` and `TapPaymentDriverRepository.all()` return `[ChipDnaDriver.shared]` instead of constructing new instances.

Net result: **zero target-list mutation after one-time setup, zero enumeration races, no `DispatchQueue.main.async` band-aids.**

## Alternatives considered and rejected

- **`DispatchQueue.main.async` around `removeTarget` inside handlers** — initial fix. Review caught a cascading race: pre-emptive `remove`/`add` in `connect`/`connectToTap` was not serialized against the deferred remove, so an off-main caller could let the deferred remove land between the pre-emptive remove and add, orphaning the fresh registration. Band-aid on band-aid — reverted.
- **Per-instance init/deinit registration** — cleaner in theory, but ChipDnaMobile's target-list reference semantics (strong vs weak) are undocumented. If strong, we leak; if weak, deinit can still fire during another instance's callback and re-crash the same way. Singleton sidesteps the ambiguity.

## Files changed

- `Sources/Fattmerchant/Cardpresent/Omni/Drivers/ChipDna/ChipDnaDriver.swift` (+85 / -35)
- `Sources/Fattmerchant/Cardpresent/Omni/Repository/MobileReaderDriverRepository.swift` (+1 / -1)
- `Sources/Fattmerchant/Cardpresent/Omni/Repository/TapPaymentDriverRepository.swift` (+1 / -1)

## Test plan

- [ ] VP3350 timeout path: attempt connect without reader powered on → expect clean `PinPadConnectionTimeout` error, no crash.
- [ ] BBPOS success path: connect BBPOS → TMS update fires → expect `connected` status, no crash.
- [ ] Multiple connect cycles: connect → disconnect → connect same reader → verify no duplicate `onConfigurationUpdate` invocations in logs.
- [ ] TTP connect success path (iOS 17.4+): expect connected delegate callback fires exactly once.
- [ ] TTP connect failure path: force `locationPermissionsNotGranted` → expect error propagates, no crash.
- [ ] Kill app mid-connect → relaunch → verify `registerCallbackTargetsIfNeeded()` re-runs on the new process and connect works.
- [ ] Crashlytics monitoring: filter on `NSGenericException` + `ChipDnaMobile` frame for 48h post-merge.

## Follow-ups (not in this PR)

- Thread safety of `onXxxCallback` properties and `callbackTargetsRegistered` flag on the shared singleton — worst case is a hung completion, not a crash; acceptable for hotfix.
- App-side: `CLLocationManager().requestWhenInUseAuthorization()` before `connectToTap` to avoid first-attempt permission-denied UX.