### PR TITLE
fix(podspec): drop deprecated VALID_ARCHS overrides so pod lib lint

### DIFF
--- a/Fattmerchant.podspec
+++ b/Fattmerchant.podspec
@@ -42,12 +42,6 @@ Pod::Spec.new do |s|
     'fattmerchant-ios-sdk/Vendor/ChipDnaMobile/BBPOSFrameworks/BBDeviceOTA-1.6.13.xcframework'
   s.pod_target_xcconfig = {
     'ENABLE_BITCODE' => 'NO',
-    'OTHER_LDFLAGS' => '-lz',
-    'VALID_ARCHS[sdk=iphonesimulator*]' => '', # No simulator support
-    'VALID_ARCHS[sdk=iphoneos*]' => 'arm64 arm64e'
-  }
-  s.user_target_xcconfig = {
-    'VALID_ARCHS[sdk=iphonesimulator*]' => '', # No simulator support
-    'VALID_ARCHS[sdk=iphoneos*]' => 'arm64 arm64e'
+    'OTHER_LDFLAGS' => '-lz'
   }
 end


### PR DESCRIPTION
…asses on Xcode 26

The empty VALID_ARCHS[sdk=iphonesimulator*] override resolves to an empty arch list under Xcode 26, leaving the simulator build with no architectures to compile. CocoaPods still drives the build downstream, so ExtractAppIntentsMetadata fails when the framework binary that was never produced cannot be found:

    error: Build input file cannot be found:
    .../Release-iphonesimulator/Fattmerchant/Fattmerchant.framework/Fattmerchant
    warning: There are no architectures to compile for because the
    VALID_ARCHS build setting is an empty list.

VALID_ARCHS has been Apple-deprecated since Xcode 12. Removing the overrides lets Xcode resolve ARCHS_STANDARD (arm64 on iOS-13+ device, arm64+x86_64 on iphonesimulator), which is what every consumer needs.